### PR TITLE
feat: ONNX object detection stage with live inference telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ interrupts operations; errors surface as log entries and tile badges.
 | **Processing chain** | Runtime-selectable OpenCV algorithms (`grayscale`, `canny`, `detect`) applied in place via a pad probe — toggled live from the console |
 | **AI inference** | YOLO-family ONNX object detection (`detect`) through OpenCV DNN: model picker and confidence slider in the console, boxes drawn into the frame, model swappable mid-stream. Inference runs on a worker thread and the probe overlays the newest result, so detection cost never throttles the stream |
 | **Inference telemetry** | Real per-pipeline detector stats over the control protocol (`stats <id>`) — latency chart, TOTAL_OBJECTS / AVG_CONFIDENCE tiles, and detections in the event log |
+| **Acceleration** | Backends auto-detected at daemon start (CPU / Vulkan / CUDA) and reported over the protocol (`accelerators`); the console renders a capability-driven selector — only detected engines are offered, `AUTO` by default, CPU when no GPU. A per-deploy CPU/GPU choice threads through the pipeline (`accel <id> <sel>`) and always resolves to a runnable backend. **The YOLO detector runs on the GPU via ncnn + Vulkan** behind an `IInferenceBackend` seam — validated on a Radeon RX 6700-series (RADV): **≈24 ms/frame vs ≈57 ms on CPU** for yolov5n at 640² (~2.4×). Enabled by `scripts/build-ncnn.sh` (`-DWITH_GPU`); the weights are converted FP16→FP32→pnnx by `scripts/fetch-models.sh` (plain `onnx2ncnn` yields a graph that crashes ncnn's Vulkan path). Colourspace convert stays on the CPU (≈1 ms). CUDA is a compiled placeholder for a future NVIDIA card |
 | **Daemon control** | `MediaFusionGCV --serve <socket>`: full text protocol (create / devices / set-device / algos / start / stop / delete / list), one connection, serialized commands |
 | **Daemon lifecycle** | Console auto-spawns the daemon if unreachable, restarts it (`REBOOT_CORE`) or shuts it down (`TERMINATE_PID`); crash → status LED + tiles fall back to `NO_SIGNAL` |
 | **Device manager** | Camera enumeration (raw V4L2 and PipeWire providers, same-node twins deduplicated) with per-device caps (resolution / format / framerate) selection; the source element is built from the selected device; only modes the CPU pipeline can negotiate are listed (DMABuf/`DMA_DRM` import is planned) |
@@ -65,7 +66,7 @@ interrupts operations; errors surface as log entries and tile badges.
 | **Telemetry** | Real per-stream FPS & throughput (sink pad probe); real host telemetry — AMD GPU temperature, VRAM, fan, GPU busy %, CPU package temp (hwmon, 1 Hz) |
 | **Observability** | App-wide event log with level filters and CSV export, including the full control-protocol transcript |
 | **Theming** | Generated QSS from design tokens; runtime accent-hue switching |
-| **Verification** | `gstreamer-check` suite (4 suites, 22 tests) + built-in self-tests: offscreen screenshot tour and a full hardware-in-the-loop stream test; GitHub Actions builds, tests and renders every page on each push to `main` |
+| **Verification** | `gstreamer-check` suite (4 suites, 25 tests) + built-in self-tests: offscreen screenshot tour and a full hardware-in-the-loop stream test; GitHub Actions builds, tests and renders every page on each push to `main` |
 
 ### Planned
 
@@ -74,7 +75,6 @@ interrupts operations; errors surface as log entries and tile badges.
 | **RAW vs AI compare** | Side-by-side comparison of the raw and processed branches of one source | engine `tee` support |
 | **More sources** | RTSP, GigE Vision, file and test sources (protocol chips already in the rail) | engine |
 | **Recording** | REC / REC ALL, freeze-frame, DVR scrubbing | engine |
-| **GPU inference** | Detector on the GPU. CPU-only today: this rig is AMD, so no CUDA, and OpenCV's OpenCL target needs an ICD that is not guaranteed present | ONNX Runtime or ncnn Vulkan |
 | **Deeper telemetry** | Frame-integrity accounting, memory bandwidth | engine |
 | **Pipeline editor** | Free node dragging & arbitrary graphs (today: fixed linear SOURCE → PROCESS → SINK, matching the engine) | engine |
 | **Remote operation** | INET sockets for console and engine on different hosts | — |
@@ -272,9 +272,11 @@ docs/
 
 1. **Engine `tee` support** — raw + processed branches from one source, unlocking the
    Compare page and per-tile RAW/processed modes.
-2. **GPU inference** — the detector is CPU-only today (~55 ms/frame for yolov5n at
-   640² on this rig). ONNX Runtime or ncnn Vulkan would give the AMD RX 6700 XT a
-   path; there is no CUDA option here.
+2. **GPU inference — done; two follow-ups.** The YOLO detector runs on ncnn + Vulkan
+   (~2.4× faster than CPU, validated on a Radeon RX 6700-series). Remaining: (a) the
+   GPU colour-convert segment is disabled — `glupload!glcolorconvert!gldownload`
+   delivered all-black frames on this RADV/GL stack, so convert stays on the CPU;
+   (b) fill in the CUDA placeholder when an NVIDIA card lands.
 3. **RTSP source** — first non-V4L2 protocol chip.
 4. **Recording** — REC / REC ALL to disk with the DVR transport bar.
 5. **Frame-integrity accounting** — drop counters and aggregate score on Analytics.

--- a/concept_A/GuiMediaFusion/core/BackendService.cpp
+++ b/concept_A/GuiMediaFusion/core/BackendService.cpp
@@ -118,6 +118,15 @@ void BackendWorker::queryModels()
     emit modelsReady(models);
 }
 
+void BackendWorker::queryAccelerators()
+{
+    QString reply;
+    QVector<AcceleratorOption> accels;
+    if (cmd(QStringLiteral("accelerators"), reply))
+        inferenceparser::parseAccelerators(reply, accels);
+    emit acceleratorsReady(accels);
+}
+
 // Sends the model + thresholds for one daemon pipeline. `detail` carries the
 // daemon's complaint when this returns false.
 bool BackendWorker::sendDetector(long daemonId, const QString& model,
@@ -171,7 +180,7 @@ void BackendWorker::pollStats()
 void BackendWorker::deploy(int sessionId, int deviceIndex, int capIndex,
                            const QString& algosCsv, bool screenSink, const QString& name,
                            const QString& detectorModel, double confidence, double nms,
-                           bool drawBoxes)
+                           bool drawBoxes, const QString& accelSelection)
 {
     const long id = createPipeline(QStringLiteral("camera"),
                                    screenSink ? QStringLiteral("screen") : QStringLiteral("app"),
@@ -190,6 +199,15 @@ void BackendWorker::deploy(int sessionId, int deviceIndex, int capIndex,
         emit sessionFailed(sessionId, QStringLiteral("set-device %1/%2 rejected: %3")
                                           .arg(deviceIndex).arg(capIndex).arg(reply));
         return;
+    }
+
+    // Select the acceleration backend before start — it shapes the pipeline
+    // topology, fixed once PLAYING. Non-fatal: the daemon resolves an unavailable
+    // pick to CPU, so a stale selection degrades rather than blocking the stream.
+    if (!accelSelection.isEmpty()) {
+        if (!cmd(QStringLiteral("accel %1 %2").arg(id).arg(accelSelection), reply)
+            || !reply.startsWith(QStringLiteral("OK")))
+            emit wire(AppLog::Warn, QStringLiteral("accel '%1' rejected: %2").arg(accelSelection, reply));
     }
 
     // Load the detector before the chain is set: makeAlgorithm("detect") picks
@@ -283,6 +301,7 @@ BackendService::BackendService(QObject* parent)
 {
     qRegisterMetaType<QVector<DeviceInfo>>("QVector<DeviceInfo>");
     qRegisterMetaType<QVector<DetectorModel>>("QVector<DetectorModel>");
+    qRegisterMetaType<QVector<AcceleratorOption>>("QVector<AcceleratorOption>");
     qRegisterMetaType<InferenceSnapshot>("InferenceSnapshot");
 
     m_worker = new BackendWorker;
@@ -317,6 +336,18 @@ BackendService::BackendService(QObject* parent)
                            .arg(names.isEmpty() ? QStringLiteral("(none — run scripts/fetch-models.sh)")
                                                 : names.join(", ")));
         emit modelsChanged(m);
+    });
+    connect(m_worker, &BackendWorker::acceleratorsReady, this,
+            [this](const QVector<AcceleratorOption>& a) {
+        m_accelerators = a;
+        QStringList avail;
+        for (const AcceleratorOption& o : a)
+            if (o.available)
+                avail << (o.device.isEmpty() ? o.backend
+                                             : QStringLiteral("%1 (%2)").arg(o.backend, o.device));
+        logInfo("CTL", QStringLiteral("accelerators: %1")
+                           .arg(avail.isEmpty() ? QStringLiteral("cpu") : avail.join(", ")));
+        emit acceleratorsChanged(a);
     });
     connect(m_worker, &BackendWorker::detectorApplied, this,
             [this](int id, bool ok, const QString& detail) {
@@ -448,6 +479,7 @@ void BackendService::onWorkerConnected(bool ok, const QString& socketPath)
         setState(DaemonState::Online);
         refreshAlgorithms();
         refreshModels();
+        refreshAccelerators();
         refreshDevices();
         return;
     }
@@ -529,13 +561,18 @@ void BackendService::refreshModels()
     QMetaObject::invokeMethod(m_worker, &BackendWorker::queryModels, Qt::QueuedConnection);
 }
 
+void BackendService::refreshAccelerators()
+{
+    QMetaObject::invokeMethod(m_worker, &BackendWorker::queryAccelerators, Qt::QueuedConnection);
+}
+
 int BackendService::deploy(const DeploySpec& spec)
 {
     const int sessionId = m_nextSession++;
     QMetaObject::invokeMethod(m_worker, [w = m_worker, sessionId, spec] {
         w->deploy(sessionId, spec.deviceIndex, spec.capIndex, spec.algosCsv,
                   spec.screenSink, spec.name, spec.detectorModel,
-                  spec.confidence, spec.nms, spec.drawBoxes);
+                  spec.confidence, spec.nms, spec.drawBoxes, spec.accelSelection);
     }, Qt::QueuedConnection);
     return sessionId;
 }

--- a/concept_A/GuiMediaFusion/core/BackendService.h
+++ b/concept_A/GuiMediaFusion/core/BackendService.h
@@ -41,9 +41,11 @@ public slots:
     void queryDevices();
     void queryAlgorithms();
     void queryModels();
+    void queryAccelerators();
     void deploy(int sessionId, int deviceIndex, int capIndex,
                 const QString& algosCsv, bool screenSink, const QString& name,
-                const QString& detectorModel, double confidence, double nms, bool drawBoxes);
+                const QString& detectorModel, double confidence, double nms, bool drawBoxes,
+                const QString& accelSelection);
     void applyDetector(int sessionId, const QString& model,
                        double confidence, double nms, bool drawBoxes);
     void pollStats();                          // one `stats` per live session
@@ -56,6 +58,7 @@ signals:
     void devicesReady(bool ok, const QVector<DeviceInfo>& devices);
     void algorithmsReady(const QStringList& algorithms);
     void modelsReady(const QVector<DetectorModel>& models);
+    void acceleratorsReady(const QVector<AcceleratorOption>& accelerators);
     void detectorApplied(int sessionId, bool ok, const QString& detail);
     void inferenceStats(int sessionId, const InferenceSnapshot& snapshot);
     void sessionStarted(int sessionId, const QString& videoSocket, const QString& description);
@@ -97,6 +100,11 @@ public:
         double  confidence  = 0.25;             // YOLOv5's own default
         double  nms         = 0.45;
         bool    drawBoxes   = true;
+
+        // Acceleration backend for this session: "auto"/"cpu"/"vulkan"/"cuda".
+        // Sent as `accel <id> <sel>` before start; the daemon resolves AUTO and
+        // falls back to CPU for anything unavailable, so a stale pick never fails.
+        QString accelSelection = QStringLiteral("auto");
     };
 
     explicit BackendService(QObject* parent = nullptr);
@@ -109,6 +117,12 @@ public:
     void    setControlSocketPath(const QString& p) { m_socketPath = p; }
     void    setBackendBinary(const QString& b)     { m_binary = b; }
     void    setAutostart(bool on)                  { m_autostart = on; }
+    QString accelSelection() const                 { return m_accelSelection; }
+    void    setAccelSelection(const QString& s) {
+        if (m_accelSelection == s) return;
+        m_accelSelection = s;
+        emit accelSelectionChanged(s);             // keep the Settings radios + Dashboard toggle in sync
+    }
 
     DaemonState state() const { return m_state; }
     qint64      daemonPid() const;
@@ -116,6 +130,7 @@ public:
     const QVector<DeviceInfo>& devices() const      { return m_devices; }
     const QStringList& algorithms() const           { return m_algorithms; }
     const QVector<DetectorModel>& models() const    { return m_models; }
+    const QVector<AcceleratorOption>& accelerators() const { return m_accelerators; }
 
     // async operations (results via signals)
     void ensureOnline();                        // connect, spawning if allowed
@@ -124,6 +139,7 @@ public:
     void refreshDevices();
     void refreshAlgorithms();
     void refreshModels();
+    void refreshAccelerators();
     int  deploy(const DeploySpec& spec);        // returns sessionId
     void stop(int sessionId);
     void stopAll();
@@ -144,6 +160,8 @@ signals:
     void sessionStopped(int sessionId);
     void sessionFailed(int sessionId, const QString& error);
     void modelsChanged(const QVector<DetectorModel>& models);
+    void acceleratorsChanged(const QVector<AcceleratorOption>& accelerators);
+    void accelSelectionChanged(const QString& selection);
     void detectorChanged(int sessionId, bool ok, const QString& detail);
     void inferenceStatsChanged(int sessionId, const InferenceSnapshot& snapshot);
 
@@ -174,5 +192,7 @@ private:
     QVector<DeviceInfo>    m_devices;
     QStringList            m_algorithms;
     QVector<DetectorModel> m_models;
+    QVector<AcceleratorOption> m_accelerators;
+    QString                m_accelSelection = QStringLiteral("auto");
     QHash<int, QString>    m_lastDetections;   // sessionId → last logged label set
 };

--- a/concept_A/GuiMediaFusion/core/InferenceTypes.cpp
+++ b/concept_A/GuiMediaFusion/core/InferenceTypes.cpp
@@ -47,6 +47,31 @@ bool inferenceparser::parseModels(const QString& reply, QVector<DetectorModel>& 
     return true;
 }
 
+bool inferenceparser::parseAccelerators(const QString& reply, QVector<AcceleratorOption>& out)
+{
+    out.clear();
+    if (!reply.startsWith(QLatin1String("OK")))
+        return false;
+
+    const QStringList lines = reply.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const QString& raw : lines) {
+        const QString line = raw.trimmed();
+        if (!line.startsWith(QLatin1String("backend=")))
+            continue;
+
+        const QStringList  tokens = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        AcceleratorOption  a;
+        a.backend   = value(tokens, QStringLiteral("backend"));
+        a.available = value(tokens, QStringLiteral("available")).toInt() != 0;
+        a.device    = tailValue(line, QStringLiteral("device"));
+        if (a.device == QLatin1String("-"))
+            a.device.clear();
+        if (!a.backend.isEmpty())
+            out.push_back(a);
+    }
+    return true;
+}
+
 bool inferenceparser::parseStats(const QString& reply, InferenceSnapshot& snapshot)
 {
     snapshot = InferenceSnapshot{};

--- a/concept_A/GuiMediaFusion/core/InferenceTypes.h
+++ b/concept_A/GuiMediaFusion/core/InferenceTypes.h
@@ -23,6 +23,14 @@ struct DetectorModel {
     QString path;
 };
 
+// One backend from the daemon's `accelerators` reply. The GUI renders a picker
+// from these: only `available` ones are selectable, plus an always-present AUTO.
+struct AcceleratorOption {
+    QString backend;              // "cpu" / "vulkan" / "cuda"
+    QString device;               // human-readable device, "" when none
+    bool    available = false;    // usable on this host with this build
+};
+
 struct DetectionBox {
     QString label;
     double  confidence = 0.0;
@@ -52,7 +60,12 @@ namespace inferenceparser {
 bool parseModels(const QString& reply, QVector<DetectorModel>& models);
 bool parseStats(const QString& reply, InferenceSnapshot& snapshot);
 
+// Parses the `accelerators` reply (lines: backend=… available=0|1 device=…).
+// True when the reply started with "OK".
+bool parseAccelerators(const QString& reply, QVector<AcceleratorOption>& out);
+
 } // namespace inferenceparser
 
 Q_DECLARE_METATYPE(DetectorModel)
 Q_DECLARE_METATYPE(InferenceSnapshot)
+Q_DECLARE_METATYPE(AcceleratorOption)

--- a/concept_A/GuiMediaFusion/pages/DashboardPage.cpp
+++ b/concept_A/GuiMediaFusion/pages/DashboardPage.cpp
@@ -223,9 +223,19 @@ QWidget* DashboardPage::buildConfigPanel()
     accelText->addWidget(m_hwLabel);
     accelLay->addLayout(accelText);
     accelLay->addStretch(1);
-    auto* accelToggle = new vos::ToggleSwitch(accelCard);
-    vos::markPlanned(accelToggle, QStringLiteral("PLANNED — inference acceleration lands with the ONNX stage"));
-    accelLay->addWidget(accelToggle);
+    m_accelToggle = new vos::ToggleSwitch(accelCard);
+    connect(m_accelToggle, &vos::ToggleSwitch::toggled, this, [this](bool on) {
+        // ON = let the detector use the GPU (AUTO resolves to Vulkan); OFF = CPU.
+        m_service->setAccelSelection(on ? QStringLiteral("auto") : QStringLiteral("cpu"));
+    });
+    connect(m_service, &BackendService::acceleratorsChanged, this,
+            [this](const QVector<AcceleratorOption>&) { refreshAccelToggle(); });
+    connect(m_service, &BackendService::accelSelectionChanged, this,
+            [this](const QString&) { refreshAccelToggle(); },
+            Qt::QueuedConnection);   // sync with Settings radios (deferred; see SettingsPage)
+    accelLay->addWidget(m_accelToggle);
+    refreshAccelToggle();
+    m_service->refreshAccelerators();
     outer->addWidget(accelCard);
 
     outer->addWidget(vos::makeHSeparator(panel));
@@ -407,6 +417,19 @@ QString DashboardPage::algosCsv() const
         if (cb->isChecked())
             active << cb->text().toLower();
     return active.join(',');
+}
+
+void DashboardPage::refreshAccelToggle()
+{
+    if (!m_accelToggle) return;
+    bool gpu = false;
+    for (const AcceleratorOption& o : m_service->accelerators())
+        if (o.available && o.backend != QLatin1String("cpu")) gpu = true;
+    m_accelToggle->setEnabled(gpu);
+    m_accelToggle->setChecked(gpu && m_service->accelSelection() != QLatin1String("cpu"));
+    m_accelToggle->setToolTip(gpu
+        ? QStringLiteral("Run the detector on the GPU (ncnn + Vulkan). Applied on the next deploy.")
+        : QStringLiteral("No GPU detected — CPU only."));
 }
 
 void DashboardPage::onStart()

--- a/concept_A/GuiMediaFusion/pages/DashboardPage.h
+++ b/concept_A/GuiMediaFusion/pages/DashboardPage.h
@@ -22,7 +22,7 @@ class QSlider;
 class QVBoxLayout;
 class VideoTile;
 
-namespace vos { class MiniBars; class KeyValueRow; class StatTile; class Badge; }
+namespace vos { class MiniBars; class KeyValueRow; class StatTile; class Badge; class ToggleSwitch; }
 
 class DashboardPage : public QWidget
 {
@@ -56,6 +56,9 @@ private:
     QWidget* buildCenterColumn();
     QWidget* buildConfigPanel();
     QString  algosCsv() const;
+    // Enables/checks the GPU_ACCELERATION toggle from detected backends + the
+    // current selection (disabled + off when no GPU is present).
+    void     refreshAccelToggle();
 
     BackendService* m_service;
     SystemMonitor*  m_monitor;
@@ -70,6 +73,7 @@ private:
     QPushButton* m_startBtn  = nullptr;
     QPushButton* m_stopBtn   = nullptr;
     QLabel*      m_hwLabel   = nullptr;
+    vos::ToggleSwitch* m_accelToggle = nullptr;   // GPU_ACCELERATION on/off
 
     // AI_INFERENCE / DETECTION_SUMMARY
     QComboBox*      m_modelBox   = nullptr;

--- a/concept_A/GuiMediaFusion/pages/PipelinePage.cpp
+++ b/concept_A/GuiMediaFusion/pages/PipelinePage.cpp
@@ -383,6 +383,7 @@ void PipelinePage::onDeploy()
     spec.name       = QStringLiteral("pipeline-editor");
     if (m_modelBox->isEnabled())
         spec.detectorModel = m_modelBox->currentData().toString();
+    spec.accelSelection = m_service->accelSelection();
     m_sessionId = m_service->deploy(spec);
     m_deployBtn->setEnabled(false);
     m_statusChip->setText(QStringLiteral("DEPLOYING…"));

--- a/concept_A/GuiMediaFusion/pages/SettingsPage.cpp
+++ b/concept_A/GuiMediaFusion/pages/SettingsPage.cpp
@@ -5,6 +5,7 @@
 #include "../theme/Theme.h"
 #include "../widgets/Components.h"
 
+#include <QAbstractButton>
 #include <QButtonGroup>
 #include <QCheckBox>
 #include <QFileDialog>
@@ -28,6 +29,10 @@ int SettingsPage::savedVerbosity()
 SettingsPage::SettingsPage(BackendService* service, QWidget* parent)
     : QWidget(parent), m_service(service)
 {
+    // Apply the persisted backend selection to the service before any deploy.
+    m_service->setAccelSelection(
+        QSettings().value(QStringLiteral("runtime/accel"), QStringLiteral("auto")).toString());
+
     auto* lay = new QVBoxLayout(this);
     lay->setContentsMargins(20, 16, 20, 16);
     lay->setSpacing(14);
@@ -144,36 +149,38 @@ QWidget* SettingsPage::buildRuntimeTab()
     auto* accelHead = new QHBoxLayout;
     accelHead->addWidget(new vos::SectionHeader(QStringLiteral("INFERENCE ACCELERATION"), accel));
     accelHead->addStretch(1);
-    accelHead->addWidget(new vos::Badge(QStringLiteral("HARDWARE: AMD RADEON (NO CUDA)"),
+    accelHead->addWidget(new vos::Badge(QStringLiteral("AUTO-DETECTED"),
                                         vos::Badge::Accent, accel));
     accelLay->addLayout(accelHead);
 
-    struct Row { const char* title; const char* desc; };
-    const Row rows[] = {
-        { "ONNX Runtime Acceleration",
-          "Planned inference engine for the FrameProcessor stage (CPU EP first, ROCm EP evaluated)." },
-        { "ncnn Vulkan Backend",
-          "Alternative lightweight engine using the Radeon's Vulkan queue." },
-    };
-    for (const Row& r : rows) {
-        auto* rowCard = vos::makeCard("raised", accel);
-        auto* rowLay = new QHBoxLayout(rowCard);
-        rowLay->setContentsMargins(12, 10, 12, 10);
-        auto* text = new QVBoxLayout;
-        text->setSpacing(3);
-        auto* t = new QLabel(QString::fromLatin1(r.title), rowCard);
-        t->setFont(theme::bodyFont(12, QFont::DemiBold));
-        auto* d = new QLabel(QString::fromLatin1(r.desc), rowCard);
-        d->setProperty("vosHint", true);
-        d->setWordWrap(true);
-        text->addWidget(t);
-        text->addWidget(d);
-        rowLay->addLayout(text, 1);
-        auto* toggle = new vos::ToggleSwitch(rowCard);
-        vos::markPlanned(toggle, QStringLiteral("PLANNED — AI stage not yet in the backend"));
-        rowLay->addWidget(toggle);
-        accelLay->addWidget(rowCard);
-    }
+    // Backend selector, built from what the daemon actually detected
+    // (`accelerators`). Only available engines are selectable, plus an
+    // always-present AUTO; with no GPU it collapses to CPU only. Applied on the
+    // next Deploy (the choice shapes the pipeline topology, fixed once PLAYING).
+    m_accelStatus = new QLabel(QStringLiteral("Detecting acceleration…"), accel);
+    m_accelStatus->setProperty("vosHint", true);
+    m_accelStatus->setWordWrap(true);
+    accelLay->addWidget(m_accelStatus);
+
+    m_accelGroup = new QButtonGroup(accel);
+    m_accelGroup->setExclusive(true);
+    auto* accelListHost = new QWidget(accel);
+    m_accelList = new QVBoxLayout(accelListHost);
+    m_accelList->setContentsMargins(0, 0, 0, 0);
+    m_accelList->setSpacing(8);
+    accelLay->addWidget(accelListHost);
+
+    rebuildAccelerators(m_service->accelerators());
+    connect(m_service, &BackendService::acceleratorsChanged,
+            this, &SettingsPage::rebuildAccelerators);
+    // Queued: this rebuild deletes and recreates the radios, and it can be
+    // triggered by a radio's own toggled() handler (radio -> setAccelSelection ->
+    // accelSelectionChanged). Deleting the button mid-signal would be a
+    // use-after-free, so defer the rebuild to the next event-loop turn.
+    connect(m_service, &BackendService::accelSelectionChanged, this,
+            [this](const QString&) { rebuildAccelerators(m_service->accelerators()); },
+            Qt::QueuedConnection);  // sync with Dashboard toggle
+    m_service->refreshAccelerators();
 
     auto* batchCard = vos::makeCard("raised", accel);
     auto* batchLay = new QVBoxLayout(batchCard);
@@ -308,6 +315,61 @@ QWidget* SettingsPage::buildPlannedTab(const QString& what)
     return host;
 }
 
+void SettingsPage::rebuildAccelerators(const QVector<AcceleratorOption>& accels)
+{
+    if (!m_accelList || !m_accelGroup)
+        return;
+
+    // Tear down the previous radios (toggled(false) fires on delete but the
+    // handler ignores it — it only acts on the newly-checked button).
+    const auto old = m_accelGroup->buttons();
+    for (QAbstractButton* b : old) {
+        m_accelGroup->removeButton(b);
+        delete b;
+    }
+
+    const QString current = m_service->accelSelection();
+    bool anyChecked = false;
+
+    auto addRadio = [&](const QString& sel, const QString& text, bool enabled, bool checked) {
+        auto* rb = new QRadioButton(text);
+        rb->setEnabled(enabled);
+        rb->setChecked(checked);
+        if (checked) anyChecked = true;
+        m_accelGroup->addButton(rb);
+        m_accelList->addWidget(rb);
+        connect(rb, &QRadioButton::toggled, this, [this, sel](bool on) {
+            if (on) m_service->setAccelSelection(sel);
+        });
+    };
+
+    // AUTO is always offered and resolves to the best available engine.
+    addRadio(QStringLiteral("auto"), QStringLiteral("AUTO — best available"),
+             true, current == QLatin1String("auto"));
+
+    QStringList gpuNames;
+    for (const AcceleratorOption& o : accels) {
+        QString label = o.backend.toUpper();
+        if (!o.device.isEmpty()) label += QStringLiteral("  ·  %1").arg(o.device);
+        if (!o.available)        label += QStringLiteral("   (unavailable)");
+        addRadio(o.backend, label, o.available, o.available && current == o.backend);
+        if (o.available && o.backend != QLatin1String("cpu"))
+            gpuNames << o.backend.toUpper();
+    }
+
+    // Persisted pick no longer available → snap back to AUTO (also corrects the
+    // stored selection via the toggled handler).
+    if (!anyChecked && !m_accelGroup->buttons().isEmpty())
+        m_accelGroup->buttons().first()->setChecked(true);
+
+    if (accels.isEmpty())
+        m_accelStatus->setText(QStringLiteral("Detecting… (backend offline?)"));
+    else if (gpuNames.isEmpty())
+        m_accelStatus->setText(QStringLiteral("No GPU detected — running on CPU."));
+    else
+        m_accelStatus->setText(QStringLiteral("GPU available: %1").arg(gpuNames.join(QStringLiteral(", "))));
+}
+
 void SettingsPage::save()
 {
     QSettings s;
@@ -317,6 +379,7 @@ void SettingsPage::save()
     s.setValue(QStringLiteral("backend/socket"), m_socketEdit->text().trimmed());
     s.setValue(QStringLiteral("backend/binary"), m_binaryEdit->text().trimmed());
     s.setValue(QStringLiteral("backend/autostart"), m_autoStart->isChecked());
+    s.setValue(QStringLiteral("runtime/accel"), m_service->accelSelection());
 
     const int lvl = qMax(0, m_verbosity->checkedId());
     s.setValue(QStringLiteral("ui/verbosity"), lvl);
@@ -337,6 +400,7 @@ void SettingsPage::exportJson()
     o.insert(QStringLiteral("controlSocket"), m_socketEdit->text());
     o.insert(QStringLiteral("backendBinary"), m_binaryEdit->text());
     o.insert(QStringLiteral("autostart"), m_autoStart->isChecked());
+    o.insert(QStringLiteral("accelSelection"), m_service->accelSelection());
     o.insert(QStringLiteral("verbosity"), m_verbosity->checkedId());
     o.insert(QStringLiteral("accent"), m_accent->checkedId());
     QFile f(path);

--- a/concept_A/GuiMediaFusion/pages/SettingsPage.h
+++ b/concept_A/GuiMediaFusion/pages/SettingsPage.h
@@ -9,10 +9,14 @@
 
 #include <QWidget>
 
+#include "../core/InferenceTypes.h"   // AcceleratorOption
+
 class BackendService;
 class QLineEdit;
 class QCheckBox;
 class QButtonGroup;
+class QVBoxLayout;
+class QLabel;
 
 class SettingsPage : public QWidget
 {
@@ -33,6 +37,9 @@ private:
     QWidget* buildPlannedTab(const QString& what);
     void     save();
     void     exportJson();
+    // Repopulates the backend-selector radios from a detection result — only
+    // available engines are enabled, plus an always-present AUTO.
+    void     rebuildAccelerators(const QVector<AcceleratorOption>& accels);
 
     BackendService* m_service;
     QLineEdit*    m_socketEdit = nullptr;
@@ -41,4 +48,7 @@ private:
     QButtonGroup* m_verbosity  = nullptr;
     QButtonGroup* m_accent     = nullptr;
     QCheckBox*    m_ledPulse   = nullptr;
+    QButtonGroup* m_accelGroup  = nullptr;   // backend radios (auto/cpu/vulkan/cuda)
+    QVBoxLayout*  m_accelList   = nullptr;   // container repopulated on detection
+    QLabel*       m_accelStatus = nullptr;   // "GPU available: …" / "CPU only"
 };

--- a/concept_A/MediaFusionGCV/AccelBackend.cpp
+++ b/concept_A/MediaFusionGCV/AccelBackend.cpp
@@ -1,0 +1,38 @@
+#include "AccelBackend.h"
+
+#include <cctype>
+
+const char* accelBackendName(AccelBackend b)
+{
+    switch (b) {
+        case AccelBackend::CPU:    return "cpu";
+        case AccelBackend::VULKAN: return "vulkan";
+        case AccelBackend::CUDA:   return "cuda";
+    }
+    return "cpu";
+}
+
+const char* accelSelectionName(AccelSelection s)
+{
+    switch (s) {
+        case AccelSelection::AUTO:   return "auto";
+        case AccelSelection::CPU:    return "cpu";
+        case AccelSelection::VULKAN: return "vulkan";
+        case AccelSelection::CUDA:   return "cuda";
+    }
+    return "auto";
+}
+
+bool parseAccelSelection(const std::string& token, AccelSelection& out)
+{
+    std::string t;
+    t.reserve(token.size());
+    for (char c : token)
+        t += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+
+    if (t == "auto")                 { out = AccelSelection::AUTO;   return true; }
+    if (t == "cpu")                  { out = AccelSelection::CPU;    return true; }
+    if (t == "vulkan" || t == "gpu") { out = AccelSelection::VULKAN; return true; }
+    if (t == "cuda")                 { out = AccelSelection::CUDA;   return true; }
+    return false;
+}

--- a/concept_A/MediaFusionGCV/AccelBackend.h
+++ b/concept_A/MediaFusionGCV/AccelBackend.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// The concrete acceleration engine a pipeline actually runs on. Resolved from an
+// AccelSelection (below) against what the host really has — see
+// AcceleratorRegistry. CPU is always available; the others depend on hardware,
+// drivers, and build flags, so a resolved backend is never assumed, only chosen.
+enum struct AccelBackend : int32_t
+{
+    CPU    = 0,   // OpenCV cv::dnn + host cv::Mat — always available
+    VULKAN = 1,   // ncnn + Vulkan (AMD/RDNA2 today; any Vulkan device), WITH_GPU
+    CUDA   = 2    // NVIDIA — placeholder, compiled in behind WITH_CUDA
+};
+
+// What the operator asked for. AUTO resolves to the best AVAILABLE backend
+// (CUDA > VULKAN > CPU); a specific pick forces that engine but still falls back
+// to CPU when it is unavailable at deploy time, so a stale selection never fails
+// a stream — it just degrades.
+enum struct AccelSelection : int32_t
+{
+    AUTO   = 0,
+    CPU    = 1,
+    VULKAN = 2,
+    CUDA   = 3
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+#include <string>
+
+// One row of the init-time capability probe (AcceleratorRegistry).
+struct AcceleratorInfo
+{
+    AccelBackend backend   = AccelBackend::CPU;
+    std::string  device    = "";      // human-readable device name, or "" if none
+    bool         available = false;   // usable on this host with this build
+};
+
+// Protocol/log spellings. Backend: "cpu"/"vulkan"/"cuda"; selection adds "auto".
+const char* accelBackendName(AccelBackend b);
+const char* accelSelectionName(AccelSelection s);
+
+// Parses "auto|cpu|vulkan|cuda" (case-insensitive; "gpu" is an alias for vulkan).
+bool parseAccelSelection(const std::string& token, AccelSelection& out);
+#endif

--- a/concept_A/MediaFusionGCV/AcceleratorRegistry.cpp
+++ b/concept_A/MediaFusionGCV/AcceleratorRegistry.cpp
@@ -1,0 +1,91 @@
+#include "AcceleratorRegistry.h"
+
+#ifdef MEDIAFUSION_WITH_GPU
+#include <gpu.h>   // ncnn: the target's include dir is <prefix>/include/ncnn
+
+#include <cstdio>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+std::vector<AcceleratorInfo> probe()
+{
+    std::vector<AcceleratorInfo> out;
+
+    // CPU is the floor: OpenCV cv::dnn / host cv::Mat always run.
+    out.push_back({ AccelBackend::CPU, "CPU (OpenCV)", true });
+
+    // VULKAN is offered only when ncnn+Vulkan is compiled in AND the driver
+    // enumerates at least one device. Without WITH_GPU there is no engine to run
+    // it, so it stays unavailable even on a box that has a Vulkan-capable GPU —
+    // the honest thing to report, since selecting it could not do inference.
+    AcceleratorInfo vk{ AccelBackend::VULKAN, "", false };
+#ifdef MEDIAFUSION_WITH_GPU
+    // ncnn prints a block of adapter capabilities to stderr the first time it
+    // creates the Vulkan instance (which get_gpu_count() does). That is noise in
+    // the daemon log, so silence fd 2 just around the probe; our own diagnostics
+    // go through separate calls and are unaffected. The instance is left alive on
+    // purpose — the ncnn detector backend reuses it, and detection is cached, so
+    // this whole block runs once per process.
+    fflush(stderr);
+    const int savedErr = dup(STDERR_FILENO);
+    const int devnull  = open("/dev/null", O_WRONLY);
+    if (devnull >= 0) { dup2(devnull, STDERR_FILENO); close(devnull); }
+
+    if (ncnn::get_gpu_count() > 0) {
+        vk.available = true;
+        const ncnn::GpuInfo& g = ncnn::get_gpu_info(0);
+        vk.device = g.device_name();
+    }
+
+    fflush(stderr);
+    if (savedErr >= 0) { dup2(savedErr, STDERR_FILENO); close(savedErr); }
+#endif
+    out.push_back(vk);
+
+    // CUDA is the NVIDIA placeholder. The row always exists so the GUI can show
+    // it the moment the hardware/build lands; today it never reports available.
+    AcceleratorInfo cu{ AccelBackend::CUDA, "", false };
+#ifdef MEDIAFUSION_WITH_CUDA
+    // TODO(nvidia): probe cudaGetDeviceCount()/cv::cuda::getCudaEnabledDeviceCount
+    // and fill cu.device/cu.available once a CUDA inference backend exists.
+#endif
+    out.push_back(cu);
+
+    return out;
+}
+
+} // namespace
+
+const std::vector<AcceleratorInfo>& detectAccelerators()
+{
+    // Function-local static: thread-safe one-time init, cached for the process.
+    static const std::vector<AcceleratorInfo> cached = probe();
+    return cached;
+}
+
+AccelBackend resolveBackend(AccelSelection selection)
+{
+    const auto& acc = detectAccelerators();
+    auto available = [&](AccelBackend b) {
+        for (const auto& a : acc)
+            if (a.backend == b) return a.available;
+        return false;
+    };
+
+    switch (selection) {
+        case AccelSelection::CPU:
+            return AccelBackend::CPU;
+        case AccelSelection::VULKAN:
+            return available(AccelBackend::VULKAN) ? AccelBackend::VULKAN : AccelBackend::CPU;
+        case AccelSelection::CUDA:
+            return available(AccelBackend::CUDA) ? AccelBackend::CUDA : AccelBackend::CPU;
+        case AccelSelection::AUTO:
+        default:
+            if (available(AccelBackend::CUDA))   return AccelBackend::CUDA;
+            if (available(AccelBackend::VULKAN)) return AccelBackend::VULKAN;
+            return AccelBackend::CPU;
+    }
+}

--- a/concept_A/MediaFusionGCV/AcceleratorRegistry.h
+++ b/concept_A/MediaFusionGCV/AcceleratorRegistry.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "AccelBackend.h"
+
+#include <vector>
+
+// Probes the host ONCE for the acceleration backends it can run and caches the
+// result. Detection has real side-effecting cost (creating a Vulkan instance to
+// enumerate devices), so it runs at init — never per-frame or per-deploy — and
+// the cached list is what the control protocol reports to the GUI, which renders
+// only the backends whose `available` is true.
+const std::vector<AcceleratorInfo>& detectAccelerators();
+
+// Resolves an operator selection against the detected capabilities:
+//   AUTO   -> best available (CUDA > VULKAN > CPU)
+//   CPU    -> CPU
+//   VULKAN -> VULKAN if available, else CPU
+//   CUDA   -> CUDA   if available, else CPU
+// The result is always a backend the host can actually run, so callers never
+// have to re-check availability.
+AccelBackend resolveBackend(AccelSelection selection);

--- a/concept_A/MediaFusionGCV/Algorithm.h
+++ b/concept_A/MediaFusionGCV/Algorithm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "InferenceStats.h"
+#include "AccelBackend.h"
 
 #include <opencv2/core.hpp>
 
@@ -21,6 +22,12 @@ public:
     virtual ~Algorithm() = default;
     virtual const char* name() const = 0;
     virtual void        apply(cv::Mat& frame) = 0;
+
+    // Optional: choose the acceleration backend this stage runs on. Called
+    // before the stage processes frames and again whenever the resolved backend
+    // changes. Plain CPU OpenCV ops ignore it; an inference stage uses it to pick
+    // between its cv::dnn (CPU) and ncnn-Vulkan / CUDA engines.
+    virtual void        setAccel(AccelBackend) {}
 
     // Optional: an inference stage reports what it last produced here so the
     // control protocol can serve DETECTION_SUMMARY / latency telemetry without

--- a/concept_A/MediaFusionGCV/Algorithms.cpp
+++ b/concept_A/MediaFusionGCV/Algorithms.cpp
@@ -2,35 +2,84 @@
 #include "Detector.h"
 
 #include <opencv2/imgproc.hpp>
+#include <opencv2/core/ocl.hpp>
 
 namespace {
 
-// Both keep the BGR/CV_8UC3 layout the pipeline expects (convert back after a
-// single-channel step) so they can be chained in any order.
+// Both filters keep the BGR/CV_8UC3 layout the pipeline expects (convert back
+// after a single-channel step) so they can be chained in any order.
+//
+// GPU path: when a GPU backend is selected these run through OpenCV's T-API
+// (cv::UMat), which dispatches cvtColor/Canny to OpenCL. That is a different
+// runtime from the detector's Vulkan (ncnn) — the filters are cheap enough that
+// a second GPU stack is not worth it — but it shares the "GPU vs CPU" switch and
+// falls back to the CPU path when no OpenCL device/ICD is present, so it is safe
+// on any machine. The pad probe hands us a cv::Mat over the pipeline buffer, so
+// the GPU path uploads a copy and downloads the result back into `frame` to keep
+// the in-place contract (see FrameProcessor).
+
+// Enable OpenCL globally when a GPU backend is chosen; useOpenCL() then reports
+// whether a device actually exists, which is what each apply() checks.
+bool wantOpenCL(AccelBackend b)
+{
+    if (b == AccelBackend::CPU)
+        return false;
+    cv::ocl::setUseOpenCL(true);
+    return cv::ocl::useOpenCL();
+}
 
 class GrayscaleAlgorithm : public Algorithm
 {
 public:
     const char* name() const override { return "grayscale"; }
+
+    void setAccel(AccelBackend b) override { m_gpu = wantOpenCL(b); }
+
     void apply(cv::Mat& frame) override
     {
+        if (m_gpu && cv::ocl::useOpenCL()) {
+            cv::UMat uframe, ugray;
+            frame.copyTo(uframe);
+            cv::cvtColor(uframe, ugray, cv::COLOR_BGR2GRAY);
+            cv::cvtColor(ugray, uframe, cv::COLOR_GRAY2BGR);
+            uframe.copyTo(frame);
+            return;
+        }
         cv::Mat gray;
         cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
         cv::cvtColor(gray, frame, cv::COLOR_GRAY2BGR);
     }
+
+private:
+    bool m_gpu = false;
 };
 
 class CannyEdgesAlgorithm : public Algorithm
 {
 public:
     const char* name() const override { return "canny"; }
+
+    void setAccel(AccelBackend b) override { m_gpu = wantOpenCL(b); }
+
     void apply(cv::Mat& frame) override
     {
+        if (m_gpu && cv::ocl::useOpenCL()) {
+            cv::UMat uframe, ugray, uedges;
+            frame.copyTo(uframe);
+            cv::cvtColor(uframe, ugray, cv::COLOR_BGR2GRAY);
+            cv::Canny(ugray, uedges, 80.0, 160.0);
+            cv::cvtColor(uedges, uframe, cv::COLOR_GRAY2BGR);
+            uframe.copyTo(frame);
+            return;
+        }
         cv::Mat gray, edges;
         cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
         cv::Canny(gray, edges, 80.0, 160.0);
         cv::cvtColor(edges, frame, cv::COLOR_GRAY2BGR);
     }
+
+private:
+    bool m_gpu = false;
 };
 
 } // namespace

--- a/concept_A/MediaFusionGCV/CMakeLists.txt
+++ b/concept_A/MediaFusionGCV/CMakeLists.txt
@@ -24,6 +24,18 @@ endforeach()
 pkg_check_modules(opencv REQUIRED IMPORTED_TARGET opencv4>=4.8)
 message(STATUS "OpenCV ${opencv_VERSION} (${opencv_PREFIX})")
 
+# ── Optional GPU acceleration ─────────────────────────────────────────────────
+# WITH_GPU pulls in ncnn (built with Vulkan) for the detector's GPU path. It is
+# auto-detected: a machine without ncnn (CI, a fresh clone) still builds, CPU
+# only, exactly like it degrades to "no models available". scripts/build-ncnn.sh
+# installs a suitable ncnn into ~/.local, discovered via CMAKE_PREFIX_PATH below.
+# WITH_CUDA is the NVIDIA placeholder — OFF until that hardware exists; its code
+# paths are #ifdef'd out, not stubbed at runtime, so nothing NVIDIA links today.
+list(APPEND CMAKE_PREFIX_PATH "$ENV{HOME}/.local" "/opt/ncnn")
+find_package(ncnn QUIET)
+option(WITH_GPU  "GPU inference via ncnn + Vulkan"          ${ncnn_FOUND})
+option(WITH_CUDA "NVIDIA/CUDA inference backend (placeholder)" OFF)
+
 # ── Shared library (everything except main.cpp) ───────────────────────────────
 set(LIB_SOURCES
     GStreamerSink.cpp
@@ -36,7 +48,10 @@ set(LIB_SOURCES
     FrameProcessor.cpp
     Algorithms.cpp
     Detector.cpp
+    InferenceBackend.cpp
     ModelRegistry.cpp
+    AccelBackend.cpp
+    AcceleratorRegistry.cpp
 )
 
 add_library(MediaFusionGCV_Lib STATIC ${LIB_SOURCES})
@@ -51,6 +66,23 @@ target_link_libraries(MediaFusionGCV_Lib PUBLIC
     PkgConfig::gstreamer-video
     PkgConfig::opencv
 )
+
+if(WITH_GPU)
+    find_package(Vulkan REQUIRED)
+    target_sources(MediaFusionGCV_Lib PRIVATE InferenceBackendNcnn.cpp)
+    target_link_libraries(MediaFusionGCV_Lib PUBLIC ncnn Vulkan::Vulkan)
+    target_compile_definitions(MediaFusionGCV_Lib PUBLIC MEDIAFUSION_WITH_GPU)
+    message(STATUS "GPU inference: ncnn ${ncnn_VERSION} + Vulkan ENABLED")
+else()
+    message(STATUS "GPU inference: DISABLED (ncnn not found) -- CPU-only build")
+endif()
+
+if(WITH_CUDA)
+    # Placeholder: no CUDA libs are linked yet; the backend is a compiled stub.
+    target_sources(MediaFusionGCV_Lib PRIVATE InferenceBackendCuda.cpp)
+    target_compile_definitions(MediaFusionGCV_Lib PUBLIC MEDIAFUSION_WITH_CUDA)
+    message(STATUS "CUDA backend: placeholder compiled in (no NVIDIA libs linked)")
+endif()
 
 # ── Main executable ───────────────────────────────────────────────────────────
 add_executable(${PROJECT_NAME} main.cpp)

--- a/concept_A/MediaFusionGCV/Detector.cpp
+++ b/concept_A/MediaFusionGCV/Detector.cpp
@@ -1,27 +1,13 @@
 #include "Detector.h"
+#include "ModelRegistry.h"
 
 #include <opencv2/imgproc.hpp>
 
-#include <algorithm>
-#include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <iostream>
 
 namespace {
-
-// Pads to a square with the image at the top-left corner. Keeping the padding
-// on the bottom/right means detections map back to frame coordinates with one
-// uniform scale factor and no centring offset to undo.
-cv::Mat squarePadded(const cv::Mat& src)
-{
-    const int side = std::max(src.cols, src.rows);
-    if (side == src.cols && side == src.rows)
-        return src;
-
-    cv::Mat square = cv::Mat::zeros(side, side, src.type());
-    src.copyTo(square(cv::Rect(0, 0, src.cols, src.rows)));
-    return square;
-}
 
 // A distinct, readable colour per class id (golden-angle walk over hue).
 cv::Scalar classColor(int classId)
@@ -57,6 +43,15 @@ DetectorConfig DetectorAlgorithm::config() const
     return m_config;
 }
 
+void DetectorAlgorithm::setAccel(AccelBackend backend)
+{
+    // Just record it; configure() reads it when (re)building the net and the
+    // factory maps it to a concrete engine. The backend is already resolved to
+    // something runnable upstream (AcceleratorRegistry), and a GPU engine that
+    // still cannot load a given model falls back to cv::dnn in configure().
+    m_accelBackend.store(backend, std::memory_order_relaxed);
+}
+
 bool DetectorAlgorithm::configure(const DetectorConfig& cfg)
 {
     {
@@ -64,19 +59,18 @@ bool DetectorAlgorithm::configure(const DetectorConfig& cfg)
         m_config = cfg;
     }
 
-    // No model selected: unload and go quiet. The stage stays in the chain as
-    // a no-op rather than erroring, so "detect" is always a valid algorithm
-    // name even on a machine with no weights fetched.
+    // No model selected: unload and go quiet. The stage stays in the chain as a
+    // no-op rather than erroring, so "detect" is always a valid algorithm name
+    // even on a machine with no weights fetched.
     if (cfg.model.empty()) {
         m_netReady.store(false, std::memory_order_release);
         {
             std::lock_guard<std::mutex> lk(m_netMutex);
-            m_net = cv::dnn::Net();
-            m_labels.clear();
-            m_model = ModelInfo{};
+            m_backend.reset();
         }
         std::lock_guard<std::mutex> lk(m_resultMutex);
         m_loadedModel.clear();
+        m_activeBackend.clear();
         m_lastError.clear();
         m_detections.clear();
         return true;
@@ -92,44 +86,39 @@ bool DetectorAlgorithm::configure(const DetectorConfig& cfg)
         return false;
     }
 
-    cv::dnn::Net net;
-    try {
-        net = cv::dnn::readNetFromONNX(info.path);
-    } catch (const cv::Exception& e) {
-        m_netReady.store(false, std::memory_order_release);
-        std::lock_guard<std::mutex> lk(m_resultMutex);
-        m_lastError = std::string("cannot read ") + info.path + ": " + e.what();
-        m_loadedModel.clear();
-        m_detections.clear();
-        return false;
+    const AccelBackend want = m_accelBackend.load(std::memory_order_relaxed);
+    std::string        err;
+    auto               backend = makeInferenceBackend(want);
+
+    if (!backend || !backend->load(info, err)) {
+        // Graceful fallback: a GPU engine that cannot load this model (e.g. the
+        // .param/.bin have not been generated yet) drops to cv::dnn rather than
+        // leaving the stage dark. CPU is the floor and is always present.
+        if (want != AccelBackend::CPU) {
+            std::cerr << "detector: " << (backend ? backend->backendName() : "gpu")
+                      << " load failed (" << err << "); falling back to cv::dnn\n";
+            backend = makeCvDnnBackend();
+            err.clear();
+        }
+        if (!backend || !backend->load(info, err)) {
+            m_netReady.store(false, std::memory_order_release);
+            std::lock_guard<std::mutex> lk(m_resultMutex);
+            m_lastError = "cannot load " + info.name + ": " + err;
+            m_loadedModel.clear();
+            m_detections.clear();
+            return false;
+        }
     }
 
-    if (net.empty()) {
-        m_netReady.store(false, std::memory_order_release);
-        std::lock_guard<std::mutex> lk(m_resultMutex);
-        m_lastError = "empty network: " + info.path;
-        m_loadedModel.clear();
-        m_detections.clear();
-        return false;
-    }
-
-    // CPU inference: this rig is AMD, so there is no CUDA path, and OpenCL
-    // through DNN_TARGET_OPENCL needs an ICD that is not guaranteed present.
-    // The console's GPU_ACCELERATION control stays PLANNED for that reason.
-    net.setPreferableBackend(cv::dnn::DNN_BACKEND_OPENCV);
-    net.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);
-
-    std::vector<std::string> labels = loadLabels(info.labelsPath);
-
+    const std::string engine = backend->backendName();
     {
         std::lock_guard<std::mutex> lk(m_netMutex);
-        m_net    = std::move(net);
-        m_labels = std::move(labels);
-        m_model  = info;
+        m_backend = std::move(backend);
     }
     {
         std::lock_guard<std::mutex> lk(m_resultMutex);
         m_loadedModel    = info.name;
+        m_activeBackend  = engine;
         m_lastError.clear();
         m_detections.clear();
         m_inferenceMs    = 0.0;
@@ -137,6 +126,7 @@ bool DetectorAlgorithm::configure(const DetectorConfig& cfg)
         m_framesInferred = 0;
         m_framesSkipped  = 0;
     }
+    std::cerr << "detector: loaded " << info.name << " on " << engine << "\n";
     m_netReady.store(true, std::memory_order_release);
     return true;
 }
@@ -221,23 +211,19 @@ void DetectorAlgorithm::inferenceLoop()
         if (job.empty())
             continue;
 
+        const DetectorConfig   cfg = config();
         double                 elapsedMs = 0.0;
         std::vector<Detection> dets;
         std::string            error;
         {
             std::lock_guard<std::mutex> lk(m_netMutex);
-            if (!m_net.empty()) {
-                try {
-                    dets = runInference(job, elapsedMs);
-                } catch (const cv::Exception& e) {
-                    error = e.what();
-                }
-            }
+            if (m_backend)
+                m_backend->infer(job, cfg, dets, elapsedMs, error);
         }
 
         if (!error.empty()) {
-            // A graph the importer accepted but cannot run: stop trying, and
-            // let the console show why instead of flooding the log.
+            // A graph the backend accepted but cannot run: stop trying, and let
+            // the console show why instead of flooding the log.
             m_netReady.store(false, std::memory_order_release);
             std::lock_guard<std::mutex> lk(m_resultMutex);
             m_lastError = "inference failed: " + error;
@@ -248,118 +234,13 @@ void DetectorAlgorithm::inferenceLoop()
     }
 }
 
-// Called with m_netMutex held.
-std::vector<Detection> DetectorAlgorithm::runInference(const cv::Mat& frame, double& elapsedMs)
-{
-    const auto start = std::chrono::steady_clock::now();
-
-    const DetectorConfig cfg       = config();
-    const int            inputSize = m_model.inputSize > 0 ? m_model.inputSize : 640;
-
-    cv::Mat blob;
-    cv::dnn::blobFromImage(squarePadded(frame), blob, 1.0 / 255.0,
-                           cv::Size(inputSize, inputSize), cv::Scalar(),
-                           /*swapRB=*/true, /*crop=*/false);
-
-    std::vector<cv::Mat> outputs;
-    m_net.setInput(blob);
-    m_net.forward(outputs, m_net.getUnconnectedOutLayersNames());
-
-    elapsedMs = std::chrono::duration<double, std::milli>(
-                    std::chrono::steady_clock::now() - start).count();
-
-    if (outputs.empty() || outputs[0].dims != 3)
-        return {};
-
-    // Two layouts are in the wild for YOLO ONNX exports:
-    //   v5: [1, anchors, 5 + classes] — box, objectness, then class scores
-    //   v8: [1, 4 + classes, anchors] — transposed, and with no objectness
-    // Which one this is follows from which dimension is larger.
-    cv::Mat out         = outputs[0];
-    int     rows        = out.size[1];
-    int     dimensions  = out.size[2];
-    bool    hasObjectness = true;
-
-    if (dimensions > rows) {
-        hasObjectness = false;
-        std::swap(rows, dimensions);
-        out = out.reshape(1, dimensions);
-        cv::transpose(out, out);
-    }
-    if (!out.isContinuous())
-        out = out.clone();
-
-    const int classCount = dimensions - (hasObjectness ? 5 : 4);
-    if (classCount <= 0)
-        return {};
-
-    // squarePadded() scaled the longer edge up to inputSize; undo that.
-    const float scale = static_cast<float>(std::max(frame.cols, frame.rows))
-                      / static_cast<float>(inputSize);
-
-    std::vector<int>      classIds;
-    std::vector<float>    scores;
-    std::vector<cv::Rect> boxes;
-    const float*          data = reinterpret_cast<const float*>(out.data);
-
-    for (int i = 0; i < rows; ++i, data += dimensions) {
-        const float* classScores = data + (hasObjectness ? 5 : 4);
-        float        score       = 0.0f;
-
-        if (hasObjectness && data[4] < cfg.confidence)
-            continue;                                   // cheap reject before the class scan
-
-        cv::Mat   scoreRow(1, classCount, CV_32F, const_cast<float*>(classScores));
-        cv::Point best;
-        double    bestScore = 0.0;
-        cv::minMaxLoc(scoreRow, nullptr, &bestScore, nullptr, &best);
-
-        score = hasObjectness ? data[4] * static_cast<float>(bestScore)
-                              : static_cast<float>(bestScore);
-        if (score < cfg.confidence)
-            continue;
-
-        const float cx = data[0], cy = data[1], w = data[2], h = data[3];
-        boxes.emplace_back(cvRound((cx - w * 0.5f) * scale),
-                           cvRound((cy - h * 0.5f) * scale),
-                           cvRound(w * scale), cvRound(h * scale));
-        scores.push_back(score);
-        classIds.push_back(best.x);
-    }
-
-    std::vector<int> keep;
-    cv::dnn::NMSBoxes(boxes, scores, cfg.confidence, cfg.nms, keep);
-
-    const cv::Rect          bounds(0, 0, frame.cols, frame.rows);
-    std::vector<Detection>  dets;
-    dets.reserve(keep.size());
-    for (int idx : keep) {
-        const cv::Rect box = boxes[idx] & bounds;
-        if (box.width <= 0 || box.height <= 0)
-            continue;
-
-        Detection d;
-        d.classId    = classIds[idx];
-        d.confidence = scores[idx];
-        d.x          = box.x;
-        d.y          = box.y;
-        d.width      = box.width;
-        d.height     = box.height;
-        d.label      = (d.classId >= 0 && d.classId < static_cast<int>(m_labels.size()))
-                     ? m_labels[d.classId]
-                     : "class_" + std::to_string(d.classId);
-        dets.push_back(std::move(d));
-    }
-    return dets;
-}
-
 void DetectorAlgorithm::publish(std::vector<Detection> dets, double elapsedMs)
 {
     std::lock_guard<std::mutex> lk(m_resultMutex);
     m_detections  = std::move(dets);
     m_inferenceMs = elapsedMs;
-    // EMA over roughly the last ten inferences — steady enough to display,
-    // quick enough to show a model swap.
+    // EMA over roughly the last ten inferences — steady enough to display, quick
+    // enough to show a model swap.
     m_avgInferenceMs = (m_framesInferred == 0)
                      ? elapsedMs
                      : m_avgInferenceMs * 0.9 + elapsedMs * 0.1;

--- a/concept_A/MediaFusionGCV/Detector.h
+++ b/concept_A/MediaFusionGCV/Detector.h
@@ -1,42 +1,35 @@
 #pragma once
 
 #include "Algorithm.h"
-#include "ModelRegistry.h"
+#include "DetectorConfig.h"
+#include "InferenceBackend.h"
 
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include <opencv2/core.hpp>
-#include <opencv2/dnn.hpp>
 
-// Runtime knobs for the inference stage, set from the control protocol.
-struct DetectorConfig
-{
-    std::string model;                 // model stem or .onnx path; "" = idle
-    float       confidence = 0.25f;    // keep detections at/above this score
-    float       nms        = 0.45f;    // IoU threshold for non-maximum suppression
-    bool        drawBoxes  = true;     // overlay boxes+labels on the frame
-};
-
-// The object-detection stage: a YOLO-family ONNX graph run through OpenCV's DNN
-// module, registered in the algorithm factory as "detect".
+// The object-detection stage, registered in the algorithm factory as "detect".
+// The actual forward pass lives behind IInferenceBackend (cv::dnn on CPU,
+// ncnn+Vulkan on GPU, CUDA placeholder) so this class only orchestrates:
+// scheduling, latency/telemetry, and drawing.
 //
 // Inference does NOT run on the streaming thread. apply() hands a copy of the
-// frame to a worker thread when that worker is idle and immediately overlays
-// the most recent completed result, so a 40 ms inference never becomes 40 ms of
-// pipeline backpressure — the stream keeps the camera's frame rate and boxes
-// lag by a frame or two. framesSkipped in InferenceStats counts frames drawn
-// from a previous result, which is what makes the console's inference-latency
-// figure meaningful separately from FPS.
+// frame to a worker thread when that worker is idle and immediately overlays the
+// most recent completed result, so a 40 ms inference never becomes 40 ms of
+// pipeline backpressure — the stream keeps the camera's frame rate and boxes lag
+// by a frame or two. framesSkipped in InferenceStats counts frames drawn from a
+// previous result, which is what makes the console's inference-latency figure
+// meaningful separately from FPS.
 //
-// Why OpenCV DNN and not ONNX Runtime: OpenCV is already a dependency of this
-// library and its ONNX importer reads the same graphs, so the inference stage
-// adds no new build dependency. The seam is this class — swapping in another
-// runtime means reimplementing runInference() only.
+// The backend is chosen by the resolved acceleration selection (setAccel); a GPU
+// engine that cannot load a model falls back to cv::dnn so the stage never goes
+// dark just because the GPU weights are missing.
 class DetectorAlgorithm : public Algorithm
 {
 public:
@@ -51,30 +44,30 @@ public:
 
     bool snapshotStats(InferenceStats& out) const override;
 
-    // Loads `cfg.model` and applies the thresholds. Returns false if the graph
-    // cannot be read; the reason is left in the stats' lastError. An empty
-    // model name unloads the net and leaves the stage a no-op.
+    // Records which acceleration backend the next model load should target.
+    void setAccel(AccelBackend backend) override;
+
+    // Loads `cfg.model` on the selected backend and applies the thresholds.
+    // Returns false if the graph cannot be read; the reason is left in the stats'
+    // lastError. An empty model name unloads the net and leaves the stage a no-op.
     bool configure(const DetectorConfig& cfg);
 
     DetectorConfig config() const;
 
 private:
-    void                   inferenceLoop();
-    std::vector<Detection> runInference(const cv::Mat& frame, double& elapsedMs);
-    void                   drawDetections(cv::Mat& frame,
-                                          const std::vector<Detection>& dets) const;
-    void                   publish(std::vector<Detection> dets, double elapsedMs);
+    void inferenceLoop();
+    void drawDetections(cv::Mat& frame, const std::vector<Detection>& dets) const;
+    void publish(std::vector<Detection> dets, double elapsedMs);
 
-    // The net is touched only by the worker thread and by configure(), which
+    // The backend is touched only by the worker thread and by configure(), which
     // holds m_netMutex to swap it — never concurrently with a forward pass.
-    // apply() must never take this mutex: it would stall the streaming thread
-    // for a whole forward pass, which is exactly what the worker exists to
-    // avoid, so readiness is published separately as an atomic.
-    mutable std::mutex       m_netMutex;
-    cv::dnn::Net             m_net;
-    std::vector<std::string> m_labels;
-    ModelInfo                m_model;
-    std::atomic<bool>        m_netReady { false };
+    // apply() must never take this mutex: it would stall the streaming thread for
+    // a whole forward pass, which is exactly what the worker exists to avoid, so
+    // readiness is published separately as an atomic.
+    mutable std::mutex                 m_netMutex;
+    std::unique_ptr<IInferenceBackend> m_backend;
+    std::atomic<bool>                  m_netReady { false };
+    std::atomic<AccelBackend>          m_accelBackend { AccelBackend::CPU };
 
     mutable std::mutex m_configMutex;
     DetectorConfig     m_config;
@@ -88,6 +81,7 @@ private:
 
     mutable std::mutex     m_resultMutex;
     std::string            m_loadedModel;   // resolved stem of the resident net
+    std::string            m_activeBackend; // engine that actually loaded it
     std::vector<Detection> m_detections;
     double                 m_inferenceMs    = 0.0;
     double                 m_avgInferenceMs = 0.0;

--- a/concept_A/MediaFusionGCV/DetectorConfig.h
+++ b/concept_A/MediaFusionGCV/DetectorConfig.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+// Runtime knobs for the inference stage, set from the control protocol. Lives in
+// its own header so both the detector and the inference backends can see it
+// without a circular include (Detector.h -> InferenceBackend.h -> here).
+struct DetectorConfig
+{
+    std::string model;                 // model stem or .onnx path; "" = idle
+    float       confidence = 0.25f;    // keep detections at/above this score
+    float       nms        = 0.45f;    // IoU threshold for non-maximum suppression
+    bool        drawBoxes  = true;     // overlay boxes+labels on the frame
+};

--- a/concept_A/MediaFusionGCV/FrameProcessor.cpp
+++ b/concept_A/MediaFusionGCV/FrameProcessor.cpp
@@ -35,6 +35,11 @@ FrameProcessor::~FrameProcessor()
 void FrameProcessor::setAlgorithms(const std::vector<std::string>& names)
 {
     DetectorConfig cfg = detectorConfig();
+    AccelBackend   accel;
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        accel = m_accel;
+    }
 
     std::vector<std::unique_ptr<Algorithm>> built;
     built.reserve(names.size());
@@ -42,6 +47,9 @@ void FrameProcessor::setAlgorithms(const std::vector<std::string>& names)
         auto a = makeAlgorithm(n);
         if (!a)
             continue;
+        // Pick the resolved backend before loading so a detector configures the
+        // right engine on the spot; plain filters ignore it.
+        a->setAccel(accel);
         // A detector joining the chain inherits the model chosen earlier;
         // loading happens here, off the streaming thread.
         if (auto* det = dynamic_cast<DetectorAlgorithm*>(a.get()))
@@ -51,6 +59,16 @@ void FrameProcessor::setAlgorithms(const std::vector<std::string>& names)
 
     std::lock_guard<std::mutex> lk(m_mutex);
     m_algos = std::move(built);
+}
+
+void FrameProcessor::setAccel(AccelBackend backend)
+{
+    std::lock_guard<std::mutex> lk(m_mutex);
+    m_accel = backend;
+    // Re-target any stage already in the chain. For a detector this means the
+    // next configure()/reload runs on the new engine.
+    for (const auto& a : m_algos)
+        a->setAccel(backend);
 }
 
 bool FrameProcessor::setDetectorConfig(const DetectorConfig& cfg)

--- a/concept_A/MediaFusionGCV/FrameProcessor.h
+++ b/concept_A/MediaFusionGCV/FrameProcessor.h
@@ -40,6 +40,11 @@ public:
     void                     setAlgorithms(const std::vector<std::string>& names);
     std::vector<std::string> activeAlgorithms() const;
 
+    // Resolved acceleration backend for the chain (CPU/Vulkan/CUDA). Stored and
+    // pushed to every current and future stage, so a detector added later still
+    // runs on the selected engine. Thread-safe.
+    void                     setAccel(AccelBackend backend);
+
     // Inference-stage settings. They live here rather than inside the detector
     // because setAlgorithms() rebuilds the chain from names — the selected
     // model has to survive that, and has to be applied to a detector that
@@ -56,6 +61,7 @@ private:
 
     std::vector<std::unique_ptr<Algorithm>> m_algos;
     DetectorConfig                          m_detectorConfig;
+    AccelBackend                            m_accel = AccelBackend::CPU;
     mutable std::mutex                      m_mutex;
     GstVideoInfo                            m_info;
     bool                                    m_haveInfo = false;

--- a/concept_A/MediaFusionGCV/InferenceBackend.cpp
+++ b/concept_A/MediaFusionGCV/InferenceBackend.cpp
@@ -1,0 +1,200 @@
+#include "InferenceBackend.h"
+
+#include <opencv2/dnn.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <chrono>
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+cv::Mat squarePadded(const cv::Mat& src)
+{
+    const int side = std::max(src.cols, src.rows);
+    if (side == src.cols && side == src.rows)
+        return src;
+
+    cv::Mat square = cv::Mat::zeros(side, side, src.type());
+    src.copyTo(square(cv::Rect(0, 0, src.cols, src.rows)));
+    return square;
+}
+
+std::vector<Detection> parseYoloOutput(const cv::Mat& raw, const DetectorConfig& cfg,
+                                       const std::vector<std::string>& labels,
+                                       int frameW, int frameH, int inputSize)
+{
+    if (raw.dims != 3)
+        return {};
+
+    // Two layouts are in the wild for YOLO ONNX exports:
+    //   v5: [1, anchors, 5 + classes] — box, objectness, then class scores
+    //   v8: [1, 4 + classes, anchors] — transposed, and with no objectness
+    // Which one this is follows from which dimension is larger.
+    cv::Mat out           = raw;
+    int     rows          = out.size[1];
+    int     dimensions    = out.size[2];
+    bool    hasObjectness = true;
+
+    if (dimensions > rows) {
+        hasObjectness = false;
+        std::swap(rows, dimensions);
+        out = out.reshape(1, dimensions);
+        cv::transpose(out, out);
+    }
+    if (!out.isContinuous())
+        out = out.clone();
+
+    const int classCount = dimensions - (hasObjectness ? 5 : 4);
+    if (classCount <= 0)
+        return {};
+
+    // squarePadded() scaled the longer edge up to inputSize; undo that.
+    const float scale = static_cast<float>(std::max(frameW, frameH))
+                      / static_cast<float>(inputSize);
+
+    std::vector<int>      classIds;
+    std::vector<float>    scores;
+    std::vector<cv::Rect> boxes;
+    const float*          data = reinterpret_cast<const float*>(out.data);
+
+    for (int i = 0; i < rows; ++i, data += dimensions) {
+        const float* classScores = data + (hasObjectness ? 5 : 4);
+
+        if (hasObjectness && data[4] < cfg.confidence)
+            continue;                                   // cheap reject before the class scan
+
+        cv::Mat   scoreRow(1, classCount, CV_32F, const_cast<float*>(classScores));
+        cv::Point best;
+        double    bestScore = 0.0;
+        cv::minMaxLoc(scoreRow, nullptr, &bestScore, nullptr, &best);
+
+        const float score = hasObjectness ? data[4] * static_cast<float>(bestScore)
+                                          : static_cast<float>(bestScore);
+        if (score < cfg.confidence)
+            continue;
+
+        const float cx = data[0], cy = data[1], w = data[2], h = data[3];
+        boxes.emplace_back(cvRound((cx - w * 0.5f) * scale),
+                           cvRound((cy - h * 0.5f) * scale),
+                           cvRound(w * scale), cvRound(h * scale));
+        scores.push_back(score);
+        classIds.push_back(best.x);
+    }
+
+    std::vector<int> keep;
+    cv::dnn::NMSBoxes(boxes, scores, cfg.confidence, cfg.nms, keep);
+
+    const cv::Rect         bounds(0, 0, frameW, frameH);
+    std::vector<Detection> dets;
+    dets.reserve(keep.size());
+    for (int idx : keep) {
+        const cv::Rect box = boxes[idx] & bounds;
+        if (box.width <= 0 || box.height <= 0)
+            continue;
+
+        Detection d;
+        d.classId    = classIds[idx];
+        d.confidence = scores[idx];
+        d.x          = box.x;
+        d.y          = box.y;
+        d.width      = box.width;
+        d.height     = box.height;
+        d.label      = (d.classId >= 0 && d.classId < static_cast<int>(labels.size()))
+                     ? labels[d.classId]
+                     : "class_" + std::to_string(d.classId);
+        dets.push_back(std::move(d));
+    }
+    return dets;
+}
+
+// ── cv::dnn backend (CPU) ─────────────────────────────────────────────────────
+
+namespace {
+
+// The original inference path: a YOLO ONNX graph run through OpenCV's DNN module
+// on the CPU. This rig is AMD, so there is no CUDA path, and OpenCL through
+// DNN_TARGET_OPENCL needs an ICD that is not guaranteed present — the GPU forward
+// pass is ncnn+Vulkan's job (see InferenceBackendNcnn.cpp), not this backend's.
+class CvDnnBackend : public IInferenceBackend
+{
+public:
+    const char* backendName() const override { return "cv::dnn"; }
+
+    bool load(const ModelInfo& model, std::string& err) override
+    {
+        cv::dnn::Net net;
+        try {
+            net = cv::dnn::readNetFromONNX(model.path);
+        } catch (const cv::Exception& e) {
+            err = std::string("cannot read ") + model.path + ": " + e.what();
+            return false;
+        }
+        if (net.empty()) {
+            err = "empty network: " + model.path;
+            return false;
+        }
+        net.setPreferableBackend(cv::dnn::DNN_BACKEND_OPENCV);
+        net.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);
+
+        m_net       = std::move(net);
+        m_labels    = loadLabels(model.labelsPath);
+        m_inputSize = model.inputSize > 0 ? model.inputSize : 640;
+        return true;
+    }
+
+    bool infer(const cv::Mat& frame, const DetectorConfig& cfg,
+               std::vector<Detection>& out, double& elapsedMs, std::string& err) override
+    {
+        const auto start = std::chrono::steady_clock::now();
+
+        cv::Mat blob;
+        cv::dnn::blobFromImage(squarePadded(frame), blob, 1.0 / 255.0,
+                               cv::Size(m_inputSize, m_inputSize), cv::Scalar(),
+                               /*swapRB=*/true, /*crop=*/false);
+
+        std::vector<cv::Mat> outputs;
+        try {
+            m_net.setInput(blob);
+            m_net.forward(outputs, m_net.getUnconnectedOutLayersNames());
+        } catch (const cv::Exception& e) {
+            err = e.what();
+            return false;
+        }
+
+        elapsedMs = std::chrono::duration<double, std::milli>(
+                        std::chrono::steady_clock::now() - start).count();
+
+        out = outputs.empty()
+            ? std::vector<Detection>{}
+            : parseYoloOutput(outputs[0], cfg, m_labels, frame.cols, frame.rows, m_inputSize);
+        return true;
+    }
+
+private:
+    cv::dnn::Net             m_net;
+    std::vector<std::string> m_labels;
+    int                      m_inputSize = 640;
+};
+
+} // namespace
+
+std::unique_ptr<IInferenceBackend> makeCvDnnBackend()
+{
+    return std::make_unique<CvDnnBackend>();
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+std::unique_ptr<IInferenceBackend> makeInferenceBackend(AccelBackend backend)
+{
+    switch (backend) {
+#ifdef MEDIAFUSION_WITH_GPU
+        case AccelBackend::VULKAN: return makeNcnnVulkanBackend();
+#endif
+#ifdef MEDIAFUSION_WITH_CUDA
+        case AccelBackend::CUDA:   return makeCudaBackend();
+#endif
+        case AccelBackend::CPU:
+        default:                   return makeCvDnnBackend();
+    }
+}

--- a/concept_A/MediaFusionGCV/InferenceBackend.h
+++ b/concept_A/MediaFusionGCV/InferenceBackend.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "AccelBackend.h"
+#include "DetectorConfig.h"
+#include "InferenceStats.h"   // Detection
+#include "ModelRegistry.h"    // ModelInfo
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <opencv2/core.hpp>
+
+// The object detector's inference engine, behind one seam so the streaming code
+// in DetectorAlgorithm (worker thread, latency stats, box overlay) is fully
+// backend-agnostic. Concrete backends:
+//   - cv::dnn      — CPU, always built (OpenCV is already a dependency)
+//   - ncnn+Vulkan  — GPU on AMD/RDNA2 and any Vulkan device, WITH_GPU
+//   - CUDA         — NVIDIA placeholder, WITH_CUDA
+// One instance is owned by one DetectorAlgorithm and touched only on its worker
+// thread; load() and infer() never run concurrently.
+class IInferenceBackend
+{
+public:
+    virtual ~IInferenceBackend() = default;
+
+    // Protocol/log spelling of the engine ("cv::dnn", "ncnn-vulkan", "cuda").
+    virtual const char* backendName() const = 0;
+
+    // Load a model. Returns false and fills `err` on failure (missing file,
+    // unreadable graph, unsupported op, or — for a GPU backend — a missing
+    // converted model). Called once per configure().
+    virtual bool load(const ModelInfo& model, std::string& err) = 0;
+
+    // Run one forward pass over a BGR CV_8UC3 frame and return NMS'd detections
+    // in that frame's pixel coordinates. Sets `elapsedMs` to the forward-pass
+    // time. Returns false and fills `err` on a run failure.
+    virtual bool infer(const cv::Mat& frame, const DetectorConfig& cfg,
+                       std::vector<Detection>& out, double& elapsedMs,
+                       std::string& err) = 0;
+};
+
+// Backend factories. makeInferenceBackend() maps a RESOLVED backend (never AUTO)
+// to a concrete engine and falls back to cv::dnn for anything not compiled in,
+// so a caller can request VULKAN/CUDA unconditionally and still get a usable
+// engine on a CPU-only build.
+std::unique_ptr<IInferenceBackend> makeCvDnnBackend();
+#ifdef MEDIAFUSION_WITH_GPU
+std::unique_ptr<IInferenceBackend> makeNcnnVulkanBackend();
+#endif
+#ifdef MEDIAFUSION_WITH_CUDA
+std::unique_ptr<IInferenceBackend> makeCudaBackend();
+#endif
+std::unique_ptr<IInferenceBackend> makeInferenceBackend(AccelBackend backend);
+
+// ── Shared, backend-agnostic helpers ──────────────────────────────────────────
+
+// Letterbox to a square (image at top-left, pad bottom/right) so detections map
+// back to frame coordinates with a single scale factor and no centring offset.
+cv::Mat squarePadded(const cv::Mat& src);
+
+// Decode a YOLO output tensor into detections. Handles both export layouts:
+//   v5: [1, anchors, 5+classes]  (box, objectness, then class scores)
+//   v8: [1, 4+classes, anchors]  (transposed, no objectness)
+// which one is inferred from which dimension is larger. `raw` is the network's
+// first output as a 3-D CV_32F cv::Mat; `labels` names classes; `frameW/H` and
+// `inputSize` undo the letterbox scale. Applies cfg.confidence and cfg.nms.
+std::vector<Detection> parseYoloOutput(const cv::Mat& raw, const DetectorConfig& cfg,
+                                       const std::vector<std::string>& labels,
+                                       int frameW, int frameH, int inputSize);

--- a/concept_A/MediaFusionGCV/InferenceBackendCuda.cpp
+++ b/concept_A/MediaFusionGCV/InferenceBackendCuda.cpp
@@ -1,0 +1,44 @@
+// CUDA inference backend — a compiled PLACEHOLDER for a future NVIDIA GPU.
+//
+// The dev machine is AMD today; this file exists so that adding an NVIDIA card is
+// a drop-in, not a rewrite: the enum value (AccelBackend::CUDA), the detection
+// row (AcceleratorRegistry), the factory branch, and the GUI option are all in
+// place. It is compiled only with WITH_CUDA (OFF by default) and links no NVIDIA
+// libraries yet. load() fails cleanly, so even if something selected CUDA the
+// detector falls back to cv::dnn — and detection reports CUDA unavailable, so
+// AUTO never picks it. When the hardware lands, fill this in with the chosen
+// stack (cv::dnn CUDA target / ONNX Runtime CUDA EP / TensorRT) behind this same
+// IInferenceBackend seam.
+#ifdef MEDIAFUSION_WITH_CUDA
+
+#include "InferenceBackend.h"
+
+namespace {
+
+class CudaBackend : public IInferenceBackend
+{
+public:
+    const char* backendName() const override { return "cuda"; }
+
+    bool load(const ModelInfo&, std::string& err) override
+    {
+        err = "CUDA backend not implemented yet (placeholder for a future NVIDIA GPU)";
+        return false;
+    }
+
+    bool infer(const cv::Mat&, const DetectorConfig&,
+               std::vector<Detection>&, double&, std::string& err) override
+    {
+        err = "CUDA backend not implemented yet";
+        return false;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<IInferenceBackend> makeCudaBackend()
+{
+    return std::make_unique<CudaBackend>();
+}
+
+#endif // MEDIAFUSION_WITH_CUDA

--- a/concept_A/MediaFusionGCV/InferenceBackendNcnn.cpp
+++ b/concept_A/MediaFusionGCV/InferenceBackendNcnn.cpp
@@ -1,0 +1,149 @@
+// ncnn + Vulkan inference backend — the GPU forward pass on AMD/RDNA2 (via Mesa
+// RADV) and any other Vulkan device. Compiled only with WITH_GPU (see
+// CMakeLists); the whole file is guarded so a CPU-only build never sees ncnn.
+//
+// It targets the standard onnx2ncnn conversion of the YOLOv5 ONNX export, whose
+// single output blob carries the same [anchors, 5+classes] rows as the ONNX
+// graph — so the frame prep (letterbox to a square, resize to inputSize, BGR->RGB,
+// 1/255 normalise) and the output decode are shared with the cv::dnn backend via
+// parseYoloOutput(). Validated on a machine where scripts/build-ncnn.sh has run;
+// exotic exports with three raw detection heads would need per-anchor decoding
+// here instead.
+#ifdef MEDIAFUSION_WITH_GPU
+
+#include "InferenceBackend.h"
+
+#include <net.h>   // ncnn: the target's include dir is <prefix>/include/ncnn
+#include <gpu.h>
+
+#include <opencv2/imgproc.hpp>
+
+#include <chrono>
+#include <cstring>
+
+namespace {
+
+class NcnnVulkanBackend : public IInferenceBackend
+{
+public:
+    NcnnVulkanBackend()
+    {
+        // Minimal, canonical Vulkan setup — the same as ncnn's own benchncnn:
+        // enable Vulkan and let load_param create the GPU instance and auto-select
+        // the default device. Every other option (fp16, winograd, sgemm,
+        // lightmode) stays at ncnn's defaults, which run correctly on RADV. The
+        // earlier load/forward crashes were NOT an ncnn/option problem but a bad
+        // FP16->ncnn model conversion (null weights) — fixed at conversion time
+        // (scripts/fetch-models.sh converts the FP16 ONNX to FP32 before onnx2ncnn).
+        m_net.opt.use_vulkan_compute = true;
+    }
+
+    ~NcnnVulkanBackend() override
+    {
+        m_net.clear();
+    }
+
+    const char* backendName() const override { return "ncnn-vulkan"; }
+
+    bool load(const ModelInfo& model, std::string& err) override
+    {
+        if (model.ncnnParam.empty() || model.ncnnBin.empty()) {
+            err = "no ncnn model for '" + model.name
+                + "' (.param/.bin missing) -- run scripts/fetch-models.sh after build-ncnn.sh";
+            return false;
+        }
+        if (ncnn::get_gpu_count() <= 0) {
+            err = "no Vulkan device available";
+            return false;
+        }
+
+        m_net.clear();
+        m_net.opt.use_vulkan_compute = true;    // reassert after clear()
+
+        if (m_net.load_param(model.ncnnParam.c_str()) != 0) {
+            err = "cannot read " + model.ncnnParam;
+            return false;
+        }
+        if (m_net.load_model(model.ncnnBin.c_str()) != 0) {
+            err = "cannot read " + model.ncnnBin;
+            return false;
+        }
+
+        // First declared input/output blob — avoids hardcoding "images"/"output"
+        // across export variants.
+        const auto ins  = m_net.input_names();
+        const auto outs = m_net.output_names();
+        if (ins.empty() || outs.empty()) {
+            err = "ncnn graph has no input/output blobs: " + model.ncnnParam;
+            return false;
+        }
+        m_inputName  = ins.front();
+        m_outputName = outs.front();
+
+        m_labels    = loadLabels(model.labelsPath);
+        m_inputSize = model.inputSize > 0 ? model.inputSize : 640;
+        return true;
+    }
+
+    bool infer(const cv::Mat& frame, const DetectorConfig& cfg,
+               std::vector<Detection>& out, double& elapsedMs, std::string& err) override
+    {
+        const auto start = std::chrono::steady_clock::now();
+
+        // Same letterbox as the CPU path, then resize to the square input.
+        const cv::Mat sq = squarePadded(frame);
+        ncnn::Mat in = ncnn::Mat::from_pixels_resize(
+            sq.data, ncnn::Mat::PIXEL_BGR2RGB, sq.cols, sq.rows, m_inputSize, m_inputSize);
+
+        const float normVals[3] = { 1.0f / 255.0f, 1.0f / 255.0f, 1.0f / 255.0f };
+        in.substract_mean_normalize(nullptr, normVals);
+
+        ncnn::Mat outBlob;
+        try {
+            ncnn::Extractor ex = m_net.create_extractor();
+            ex.input(m_inputName.c_str(), in);
+            if (ex.extract(m_outputName.c_str(), outBlob) != 0) {
+                err = "ncnn extract failed for blob '" + m_outputName + "'";
+                return false;
+            }
+        } catch (const std::exception& e) {
+            err = e.what();
+            return false;
+        }
+
+        elapsedMs = std::chrono::duration<double, std::milli>(
+                        std::chrono::steady_clock::now() - start).count();
+
+        // ncnn 2-D output is [w = 5+classes, h = anchors]; wrap it as the 3-D
+        // [1, anchors, dims] CV_32F tensor parseYoloOutput expects (v5 layout).
+        const int anchors = outBlob.h;
+        const int dims    = outBlob.w;
+        if (anchors <= 0 || dims <= 0) {
+            out.clear();
+            return true;
+        }
+        const int sizes[3] = { 1, anchors, dims };
+        cv::Mat raw(3, sizes, CV_32F);
+        for (int i = 0; i < anchors; ++i)
+            std::memcpy(raw.ptr<float>(0, i), outBlob.row(i), dims * sizeof(float));
+
+        out = parseYoloOutput(raw, cfg, m_labels, frame.cols, frame.rows, m_inputSize);
+        return true;
+    }
+
+private:
+    ncnn::Net                m_net;
+    std::string              m_inputName;
+    std::string              m_outputName;
+    std::vector<std::string> m_labels;
+    int                      m_inputSize = 640;
+};
+
+} // namespace
+
+std::unique_ptr<IInferenceBackend> makeNcnnVulkanBackend()
+{
+    return std::make_unique<NcnnVulkanBackend>();
+}
+
+#endif // MEDIAFUSION_WITH_GPU

--- a/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
+++ b/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
@@ -2,7 +2,9 @@
 #include "PipelineManager.h"
 #include "Algorithms.h"
 #include "ModelRegistry.h"
+#include "AcceleratorRegistry.h"
 
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -15,6 +17,18 @@ std::vector<PipelineManager*> pipelines;
 errorState mediaLib_GStreamerInit(int argc, char* argv[])
 {
 	gst_init(&argc, &argv);
+
+	// Probe acceleration once, here, so the cost (creating a Vulkan instance to
+	// enumerate devices) is paid at startup and the detected set is ready for the
+	// first 'accelerators' query. Cached thereafter (see AcceleratorRegistry).
+	std::string summary;
+	for (const auto& a : detectAccelerators())
+		if (a.available) {
+			if (!summary.empty()) summary += ", ";
+			summary += accelBackendName(a.backend);
+			if (!a.device.empty()) summary += " (" + a.device + ")";
+		}
+	std::cerr << "accelerators detected: " << (summary.empty() ? "cpu" : summary) << "\n";
 	return errorState::NO_ERR;
 }
 
@@ -192,5 +206,25 @@ errorState mediaLib_getInferenceStats(size_t pipelineId, InferenceStats& stats)
 	if (!pipelines[pipelineId]->inferenceStats(stats))
 		return errorState::NOT_IMPLEMENTED_YET_ERR;
 	return errorState::NO_ERR;
+}
+
+const char* mediaLib_detectAccelerators()
+{
+	static thread_local std::string listing;
+	listing.clear();
+	for (const auto& a : detectAccelerators()) {
+		listing += "backend=";    listing += accelBackendName(a.backend);
+		listing += " available="; listing += (a.available ? "1" : "0");
+		listing += " device=";    listing += (a.device.empty() ? "-" : a.device);
+		listing += "\n";
+	}
+	return listing.c_str();
+}
+
+errorState mediaLib_setAccel(size_t pipelineId, int32_t selection)
+{
+	if (pipelineId >= pipelines.size() || pipelines[pipelineId] == nullptr)
+		return errorState::NULLPTR_ERR;
+	return pipelines[pipelineId]->setAccel(static_cast<AccelSelection>(selection));
 }
 

--- a/concept_A/MediaFusionGCV/MediaFusionGCV_API.h
+++ b/concept_A/MediaFusionGCV/MediaFusionGCV_API.h
@@ -92,6 +92,17 @@ extern "C" {
 	// NOT_IMPLEMENTED_YET_ERR when the chain has no inference stage.
 	MEDIAFUSIONGCV_API errorState  mediaLib_getInferenceStats(size_t, InferenceStats&);
 
+	// Acceleration backends detected on this host (probed once at init). One line
+	// per backend: "backend=<cpu|vulkan|cuda> available=<0|1> device=<name>".
+	// The GUI renders only the available ones. Pointer valid until the next call.
+	MEDIAFUSIONGCV_API const char* mediaLib_detectAccelerators();
+
+	// Selects a pipeline's acceleration backend: 0=auto, 1=cpu, 2=vulkan, 3=cuda
+	// (AccelSelection). AUTO resolves to the best available; an unavailable pick
+	// falls back to CPU. Shapes the pipeline topology, so it is applied at the
+	// next start — set it before mediaLib_startStreaming.
+	MEDIAFUSIONGCV_API errorState  mediaLib_setAccel(size_t, int32_t selection);
+
 	MEDIAFUSIONGCV_API size_t mediaLib_delete(size_t);
 	MEDIAFUSIONGCV_API void   mediaLib_destroyAll();
 

--- a/concept_A/MediaFusionGCV/ModelRegistry.cpp
+++ b/concept_A/MediaFusionGCV/ModelRegistry.cpp
@@ -27,6 +27,16 @@ bool isDirectory(const fs::path& p)
     return !p.empty() && fs::is_directory(p, ec);
 }
 
+// Path to <dir>/<name> if it is a regular file, else "". Used to pick up the
+// ncnn .param/.bin that sit next to a model's .onnx once fetch-models.sh has
+// converted them; absent is normal (CPU-only, no ncnn conversion run).
+std::string siblingFile(const fs::path& dir, const std::string& name)
+{
+    std::error_code ec;
+    fs::path p = dir / name;
+    return fs::is_regular_file(p, ec) ? p.string() : std::string();
+}
+
 // The labels that go with <dir>/<stem>.onnx: a same-named sidecar first, then
 // the shared COCO list the YOLO family uses.
 std::string findLabelsFor(const fs::path& dir, const std::string& stem)
@@ -101,6 +111,8 @@ std::vector<ModelInfo> availableModels()
             info.path       = p.string();
             info.labelsPath = findLabelsFor(p.parent_path(), stem);
             info.classCount = loadLabels(info.labelsPath).size();
+            info.ncnnParam  = siblingFile(p.parent_path(), stem + ".param");
+            info.ncnnBin    = siblingFile(p.parent_path(), stem + ".bin");
             models.push_back(std::move(info));
         }
     }
@@ -128,6 +140,8 @@ bool findModel(const std::string& nameOrPath, ModelInfo& out)
         out.path       = p.string();
         out.labelsPath = findLabelsFor(p.parent_path(), out.name);
         out.classCount = loadLabels(out.labelsPath).size();
+        out.ncnnParam  = siblingFile(p.parent_path(), out.name + ".param");
+        out.ncnnBin    = siblingFile(p.parent_path(), out.name + ".bin");
         return true;
     }
     return false;

--- a/concept_A/MediaFusionGCV/ModelRegistry.h
+++ b/concept_A/MediaFusionGCV/ModelRegistry.h
@@ -18,6 +18,8 @@ struct ModelInfo
     std::string labelsPath;       // absolute path to the labels file, "" if none
     int         inputSize  = 640; // square network input (YOLO-family default)
     size_t      classCount = 0;   // labels found, 0 when there is no sidecar
+    std::string ncnnParam;        // sibling <stem>.param for the ncnn/Vulkan backend, "" if none
+    std::string ncnnBin;          // sibling <stem>.bin, "" if none
 };
 
 // Directories searched, in priority order:

--- a/concept_A/MediaFusionGCV/PipelineManager.cpp
+++ b/concept_A/MediaFusionGCV/PipelineManager.cpp
@@ -4,6 +4,7 @@
 #include "GStreamerSinkApplication.h"
 #include "FrameProcessor.h"
 #include "ModelRegistry.h"
+#include "AcceleratorRegistry.h"
 
 PipelineManager::PipelineManager(SourceType srcType, SinkType snkType, const char* pipelineName)
 {
@@ -58,6 +59,12 @@ PipelineManager::~PipelineManager()
     delete source;    source    = nullptr;
     delete sink;      sink      = nullptr;
     delete processor; processor = nullptr;
+
+    // Drop our explicit refs on the optional GPU segment (2→1) before the bin
+    // frees its own (1→0), mirroring the source/sink ordering above.
+    for (GstElement* e : m_gpuElements)
+        if (e) gst_object_unref(e);
+    m_gpuElements.clear();
 
     if (pipeline) {
         gst_object_unref(pipeline);
@@ -136,20 +143,48 @@ std::string PipelineManager::getStreamEndpoint() const
     return sink ? sink->endpoint() : std::string();
 }
 
+void PipelineManager::ensureProcessor()
+{
+    if (processor)
+        return;
+    processor = new FrameProcessor();
+    // Adopt the chosen backend immediately. Without this, selecting GPU before
+    // the processor exists (as the GUI does: accel, then model/algos) would build
+    // a detector that configures on cv::dnn and never switches to the GPU engine.
+    processor->setAccel(m_backend);
+}
+
 void PipelineManager::setProcessingEnabled(bool enabled)
 {
-    if (enabled && !processor)
-        processor = new FrameProcessor();
+    if (enabled)
+        ensureProcessor();
     else if (!enabled && processor) {
         delete processor;
         processor = nullptr;
     }
 }
 
+errorState PipelineManager::setAccel(AccelSelection selection)
+{
+    m_accelSel = selection;
+    // Resolve now for an immediate, honest echo (AUTO -> a concrete backend) and
+    // apply to a processor that already exists. buildPipeline() re-resolves at
+    // the next start, so hardware that appears/disappears in between is still
+    // honoured and the resolved backend selects the decode topology there.
+    m_backend = resolveBackend(selection);
+    if (processor) {
+        processor->setAccel(m_backend);
+        // Reload an already-built detector on the new engine, so changing the
+        // selection after a model was chosen switches backends too — not only
+        // when accel is set before the model (the GUI's order).
+        processor->setDetectorConfig(processor->detectorConfig());
+    }
+    return errorState::NO_ERR;
+}
+
 errorState PipelineManager::setAlgorithms(const std::vector<std::string>& names)
 {
-    if (!processor)
-        processor = new FrameProcessor();   // selecting algorithms enables the stage
+    ensureProcessor();                      // selecting algorithms enables the stage
     if (!processor->valid())
         return errorState::OBJECT_CREATION_ERR;
     processor->setAlgorithms(names);
@@ -165,8 +200,7 @@ errorState PipelineManager::setDetectorModel(const std::string& modelNameOrPath)
     if (!modelNameOrPath.empty() && !findModel(modelNameOrPath, info))
         return errorState::LOAD_MODEL_ERR;
 
-    if (!processor)
-        processor = new FrameProcessor();   // model choice survives until "detect" is selected
+    ensureProcessor();                      // model choice survives until "detect" is selected
     if (!processor->valid())
         return errorState::OBJECT_CREATION_ERR;
 
@@ -179,8 +213,7 @@ errorState PipelineManager::setDetectorModel(const std::string& modelNameOrPath)
 
 errorState PipelineManager::setDetectorParams(float confidence, float nms, bool drawBoxes)
 {
-    if (!processor)
-        processor = new FrameProcessor();
+    ensureProcessor();
     if (!processor->valid())
         return errorState::OBJECT_CREATION_ERR;
 
@@ -197,11 +230,73 @@ bool PipelineManager::inferenceStats(InferenceStats& out) const
     return processor && processor->valid() && processor->inferenceStats(out);
 }
 
+// The GStreamer element chain that does the colorspace convert on the GPU for a
+// given backend, or empty if that backend has no offload path here. For a raw
+// v4l2 camera there is nothing to "decode"; the win is moving the convert off the
+// CPU. We keep the source side in system memory (glupload uploads it) rather than
+// importing DMABuf, so device enumeration is unchanged and the only added cost is
+// one upload — symmetric with the gldownload that returns the frame to the
+// in-place BGR pad probe.
+static std::vector<const char*> accelSegmentFactories(AccelBackend /*b*/)
+{
+    // GPU colorspace-convert segment, DISABLED. The glupload!glcolorconvert!
+    // gldownload chain negotiated and streamed but delivered all-black frames to
+    // the in-place BGR pad probe on this RADV/GL stack (framemean=0), which
+    // starved the detector. Colorspace convert is ~1 ms on the CPU anyway, so the
+    // high-value GPU work — the ncnn-Vulkan detector forward pass — is where the
+    // win is (≈2.4x). Left as a seam: return the element chain here once the GL
+    // download path is validated (or swap in a VA/`va` postproc that keeps data
+    // in system memory correctly).
+    return {};
+}
+
+bool PipelineManager::makeAccelSegment(std::vector<GstElement*>& out) const
+{
+    out.clear();
+    const std::vector<const char*> factories = accelSegmentFactories(m_backend);
+    if (factories.empty())
+        return false;
+
+    // All-or-nothing: if any element is missing (plugin/driver absent) drop to
+    // the CPU topology rather than build a half GPU chain that cannot link.
+    for (const char* f : factories) {
+        GstElementFactory* fac = gst_element_factory_find(f);
+        if (!fac) {
+            std::cerr << "accel: element '" << f << "' unavailable; using CPU pipeline\n";
+            return false;
+        }
+        gst_object_unref(fac);
+    }
+
+    for (const char* f : factories) {
+        GstElement* e = gst_element_factory_make(f, nullptr);
+        if (!e) {
+            for (GstElement* made : out) gst_object_unref(made);
+            out.clear();
+            return false;
+        }
+        out.push_back(e);
+    }
+    return true;
+}
+
 errorState PipelineManager::buildPipeline()
 {
     if (!source || !sink) return errorState::NULLPTR_ERR;
 
     const bool useProcessor = processor && processor->valid();
+
+    // Resolve the operator's selection against detected hardware at start time:
+    // AUTO tracks whatever is present now. On a GPU backend, try to build a GPU
+    // convert segment; a missing plugin leaves gpuSeg empty and we stay on the
+    // CPU topology, so start never fails for lack of a GPU element.
+    m_backend = resolveBackend(m_accelSel);
+    if (useProcessor)
+        processor->setAccel(m_backend);
+
+    std::vector<GstElement*> gpuSeg;
+    if (m_backend != AccelBackend::CPU && makeAccelSegment(gpuSeg))
+        std::cerr << "accel: GPU convert segment active (" << accelBackendName(m_backend) << ")\n";
 
     gst_bin_add_many(GST_BIN(pipeline),
         source->sourceElement,
@@ -225,11 +320,32 @@ errorState PipelineManager::buildPipeline()
         gst_object_ref(processor->filterElement);
     }
 
+    // Own the GPU segment the same way: bin sinks the floating ref, we keep an
+    // explicit one that the destructor drops (see m_gpuElements).
+    for (GstElement* e : gpuSeg) {
+        gst_bin_add(GST_BIN(pipeline), e);
+        gst_object_ref(e);
+        m_gpuElements.push_back(e);
+    }
+
     struct LinkStep { GstElement* from; GstElement* to; const char* desc; };
     std::vector<LinkStep> steps = {
-        { source->sourceElement, source->capsFilter, "source → src-capsfilter"        },
-        { source->capsFilter,    source->converter,  "src-capsfilter → src-converter"  },
+        { source->sourceElement, source->capsFilter, "source → src-capsfilter" },
     };
+
+    // src-capsfilter → [GPU convert segment] → src-converter. The trailing
+    // videoconvert still guarantees exact BGR/system-memory for the pad probe,
+    // so the unixfdsink memfd contract is untouched whether or not the GPU
+    // segment is present.
+    if (!gpuSeg.empty()) {
+        steps.push_back({ source->capsFilter, gpuSeg.front(), "src-capsfilter → gpu-in" });
+        for (size_t i = 1; i < gpuSeg.size(); ++i)
+            steps.push_back({ gpuSeg[i - 1], gpuSeg[i], "gpu → gpu" });
+        steps.push_back({ gpuSeg.back(), source->converter, "gpu-out → src-converter" });
+    } else {
+        steps.push_back({ source->capsFilter, source->converter, "src-capsfilter → src-converter" });
+    }
+
     if (useProcessor) {
         // Splice the BGR capsfilter in; its src-pad probe processes each buffer
         // in place (see FrameProcessor), so downstream allocation stays intact.

--- a/concept_A/MediaFusionGCV/PipelineManager.h
+++ b/concept_A/MediaFusionGCV/PipelineManager.h
@@ -10,6 +10,7 @@
 #include "SinkType.h"
 #include "errorState.h"
 #include "InferenceStats.h"
+#include "AccelBackend.h"
 
 #include "GStreamerSource.h"
 #include "GStreamerSink.h"
@@ -53,6 +54,11 @@ public:
     // False when this pipeline has no inference stage in its chain.
     bool inferenceStats(InferenceStats& out) const;
 
+    // Acceleration backend selection (auto/cpu/vulkan/cuda). Resolved against the
+    // detected hardware at the next startStreaming(), since the choice shapes the
+    // decode/convert topology built there and cannot change while PLAYING.
+    errorState setAccel(AccelSelection selection);
+
 private:
     GstElement*           pipeline       = nullptr;
     GThread*              pipelineThread = nullptr;
@@ -60,7 +66,20 @@ private:
     GStreamerSink*         sink           = nullptr;
     FrameProcessor*        processor      = nullptr;
     std::atomic<bool>     stopRequested  { false };
+    AccelSelection        m_accelSel     = AccelSelection::AUTO;
+    AccelBackend          m_backend      = AccelBackend::CPU;   // resolved at build
+    std::vector<GstElement*> m_gpuElements;                     // optional GPU convert segment
 
+    // Lazily creates the FrameProcessor, having it adopt the currently-selected
+    // backend (m_backend) at once — so a detector configured next runs on the
+    // right engine, not just from the next start().
+    void            ensureProcessor();
     errorState      buildPipeline();
+    // Builds the GPU colorspace-convert element chain for m_backend (e.g.
+    // glupload!glcolorconvert!gldownload). Returns false — leaving out empty — if
+    // the backend is CPU or any element is unavailable, so the caller stays on
+    // the CPU topology. The returned elements carry a floating ref (not yet in a
+    // bin); buildPipeline() takes ownership.
+    bool            makeAccelSegment(std::vector<GstElement*>& out) const;
     static gpointer startLoop(gpointer data);
 };

--- a/concept_A/MediaFusionGCV/main.cpp
+++ b/concept_A/MediaFusionGCV/main.cpp
@@ -1,4 +1,5 @@
 #include "MediaFusionGCV_API.h"
+#include "AccelBackend.h"
 
 #include <iostream>
 #include <sstream>
@@ -114,10 +115,12 @@ static std::string helpText()
         << "  set-device <id> <dev> <cap>      Select Device [dev] Cap [cap] from 'devices' output\n"
         << "  algos <id> <csv>                 Set OpenCV algorithm chain (empty csv disables)\n"
         << "  algos-list                       List available algorithm names\n"
+        << "  accelerators                     List detected accel backends (cpu/vulkan/cuda)\n"
         << "  models                           List installed detector models\n"
         << "  model <id> [name]                Load a detector model (no name unloads it)\n"
         << "  detect-params <id> <conf> <nms> [draw]\n"
         << "                                   Detector thresholds (0..1) and box overlay (0/1)\n"
+        << "  accel <id> <auto|cpu|vulkan|cuda>  Select accel backend (applied at next start)\n"
         << "  stats <id>                       Inference latency and last detections\n"
         << "  start <id>                       Start streaming (app sink -> prints socket path)\n"
         << "  stop <id>                        Stop streaming\n"
@@ -228,6 +231,28 @@ static std::string handleCommand(const std::string& line)
     }
     else if (cmd == "algos-list") {
         out << "OK " << mediaLib_availableAlgorithms() << "\n";
+    }
+    else if (cmd == "accelerators") {
+        // One line per backend the host can run; the GUI shows only available=1.
+        out << "OK\n" << mediaLib_detectAccelerators();
+    }
+    else if (cmd == "accel") {
+        size_t id = 0;
+        std::string sel;
+        if (!(iss >> id >> sel))
+            out << "ERR INVALID_ARGS accel <id> <auto|cpu|vulkan|cuda>\n";
+        else {
+            AccelSelection s;
+            if (!parseAccelSelection(sel, s))
+                out << "ERR INVALID_ARGS unknown backend '" << sel
+                    << "' -- use: auto cpu vulkan cuda\n";
+            else {
+                errorState err = mediaLib_setAccel(id, static_cast<int32_t>(s));
+                out << (err == errorState::NO_ERR
+                        ? ("OK " + std::string(accelSelectionName(s)) + "\n")
+                        : ("ERR " + errStr(err) + "\n"));
+            }
+        }
     }
     else if (cmd == "models") {
         const std::string listing = mediaLib_availableModels();

--- a/concept_A/MediaFusionGCV/tests/test_inference.cpp
+++ b/concept_A/MediaFusionGCV/tests/test_inference.cpp
@@ -10,6 +10,7 @@
 #include "MediaFusionGCV_API.h"
 #include "ModelRegistry.h"
 #include "Detector.h"
+#include "AcceleratorRegistry.h"
 
 // These tests must pass on a machine with no model weights installed — that is
 // the state of a fresh clone and of CI, since models/ is gitignored and fetched
@@ -147,6 +148,68 @@ GST_START_TEST(test_detector_runs_when_a_model_is_installed)
 }
 GST_END_TEST
 
+// Detection must always offer CPU, list each backend exactly once, and — on any
+// box — never contradict itself. These invariants hold with or without a GPU:
+// on a CPU-only build (no WITH_GPU) vulkan/cuda are simply reported unavailable.
+GST_START_TEST(test_accelerators_detection_invariants)
+{
+    const auto& accels = detectAccelerators();
+    fail_unless(!accels.empty(), "detection returned nothing");
+
+    bool haveCpu = false;
+    int  cpu = 0, vulkan = 0, cuda = 0;
+    for (const auto& a : accels) {
+        switch (a.backend) {
+            case AccelBackend::CPU:    ++cpu;    haveCpu = haveCpu || a.available; break;
+            case AccelBackend::VULKAN: ++vulkan; break;
+            case AccelBackend::CUDA:   ++cuda;   break;
+        }
+    }
+    fail_unless(haveCpu, "CPU must always be available");
+    fail_unless(cpu == 1 && vulkan == 1 && cuda == 1,
+        "each backend must appear exactly once (cpu=%d vulkan=%d cuda=%d)", cpu, vulkan, cuda);
+}
+GST_END_TEST
+
+// resolveBackend() must return a backend that is actually available for every
+// selection — so a stale or optimistic pick (e.g. VULKAN on a CPU-only box)
+// degrades to CPU rather than failing a stream.
+GST_START_TEST(test_resolve_backend_is_always_runnable)
+{
+    const AccelSelection sels[] = { AccelSelection::AUTO, AccelSelection::CPU,
+                                    AccelSelection::VULKAN, AccelSelection::CUDA };
+    for (AccelSelection sel : sels) {
+        const AccelBackend b = resolveBackend(sel);
+        bool available = false;
+        for (const auto& a : detectAccelerators())
+            if (a.backend == b) available = a.available;
+        fail_unless(available, "resolveBackend(%d) chose an unavailable backend %d",
+            (int)sel, (int)b);
+    }
+    fail_unless(resolveBackend(AccelSelection::CPU) == AccelBackend::CPU,
+        "explicit CPU must resolve to CPU");
+}
+GST_END_TEST
+
+// The accel control API: valid selections are accepted on a real pipeline, a
+// bad id is rejected like the rest of the API, and detection is serialisable.
+GST_START_TEST(test_accel_api)
+{
+    size_t id = mediaLib_create(SourceType::CAMERA_SOURCE, SinkType::APPLICATION_SINK, "t_accel");
+    for (int sel = 0; sel <= 3; ++sel)          // AUTO, CPU, VULKAN, CUDA
+        fail_unless(mediaLib_setAccel(id, sel) == errorState::NO_ERR,
+            "selection %d must be accepted", sel);
+    fail_unless(mediaLib_setAccel(9999, 0) == errorState::NULLPTR_ERR,
+        "a bad pipeline id must be rejected");
+
+    const std::string listing = mediaLib_detectAccelerators();
+    fail_unless(listing.find("backend=cpu") != std::string::npos,
+        "detection listing must include cpu, got '%s'", listing.c_str());
+
+    mediaLib_delete(id);
+}
+GST_END_TEST
+
 Suite* inference_suite()
 {
     Suite* s = suite_create("inference");
@@ -163,5 +226,8 @@ Suite* inference_suite()
     tcase_add_test(tc, test_params_without_model_and_stats_absent);
     tcase_add_test(tc, test_model_registry_entries_are_resolvable);
     tcase_add_test(tc, test_detector_runs_when_a_model_is_installed);
+    tcase_add_test(tc, test_accelerators_detection_invariants);
+    tcase_add_test(tc, test_resolve_backend_is_always_runnable);
+    tcase_add_test(tc, test_accel_api);
     return s;
 }

--- a/scripts/build-ncnn.sh
+++ b/scripts/build-ncnn.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Build and install ncnn (with Vulkan) for the detector's GPU inference path.
+#
+# The dev box is AMD (RDNA2) with no CUDA, so the GPU forward pass runs on ncnn's
+# Vulkan backend through Mesa RADV — the most reliable GPU route on a consumer
+# Radeon. Only MediaFusionGCV's detector links ncnn, and only when the engine is
+# configured with -DWITH_GPU=ON; without ncnn the engine still builds CPU-only
+# (cv::dnn), exactly as it degrades to "no models available".
+#
+# Installs to a user-writable prefix (no root). The engine's CMakeLists appends
+# $HOME/.local and /opt/ncnn to CMAKE_PREFIX_PATH, so find_package(ncnn) picks
+# this up and flips WITH_GPU ON automatically — no extra flags. Building the
+# tools also yields onnx2ncnn, which scripts/fetch-models.sh uses to convert the
+# YOLO weights into ncnn's .param/.bin format.
+#
+# Usage:  scripts/build-ncnn.sh [prefix]        (default: $HOME/.local)
+set -euo pipefail
+
+NCNN_VERSION="${NCNN_VERSION:-20260526}"
+PREFIX="${1:-$HOME/.local}"
+WORKDIR="${NCNN_BUILD_DIR:-${TMPDIR:-/tmp}/ncnn-build-$NCNN_VERSION}"
+JOBS="${JOBS:-$(nproc)}"
+
+echo "==> ncnn $NCNN_VERSION (Vulkan) -> $PREFIX (build in $WORKDIR, -j$JOBS)"
+
+# Vulkan headers/loader are required for NCNN_VULKAN. Warn early if absent so the
+# failure is legible rather than a mid-build missing-header error.
+if ! pkg-config --exists vulkan; then
+    echo "!! Vulkan dev files not found (apt: libvulkan-dev mesa-vulkan-drivers)." >&2
+    echo "!! ncnn vendors glslang as a submodule, so the shader compiler is handled;" >&2
+    echo "!! only the Vulkan loader/headers must be present." >&2
+fi
+
+mkdir -p "$WORKDIR"
+if [ ! -d "$WORKDIR/ncnn/.git" ]; then
+    # --recursive: ncnn vendors glslang (the Vulkan shader compiler) as a submodule.
+    git clone --depth 1 --branch "$NCNN_VERSION" --recursive \
+        https://github.com/Tencent/ncnn.git "$WORKDIR/ncnn"
+fi
+
+# Static lib keeps deployment simple (one .a folded into the engine, like the
+# rest of MediaFusionGCV_Lib). Tools ON so we get onnx2ncnn; examples/tests/bench
+# OFF to keep the build short.
+cmake -S "$WORKDIR/ncnn" -B "$WORKDIR/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+    -DNCNN_VULKAN=ON \
+    -DNCNN_BUILD_TOOLS=ON \
+    -DNCNN_BUILD_EXAMPLES=OFF \
+    -DNCNN_BUILD_BENCHMARK=OFF \
+    -DNCNN_BUILD_TESTS=OFF \
+    -DNCNN_SHARED_LIB=OFF
+
+cmake --build "$WORKDIR/build" -j"$JOBS"
+cmake --install "$WORKDIR/build"
+
+# onnx2ncnn is a build tool, not part of the library install; expose it on PATH
+# for scripts/fetch-models.sh (which looks in $PREFIX/bin).
+if [ -x "$WORKDIR/build/tools/onnx/onnx2ncnn" ]; then
+    install -Dm755 "$WORKDIR/build/tools/onnx/onnx2ncnn" "$PREFIX/bin/onnx2ncnn"
+    echo "==> installed onnx2ncnn -> $PREFIX/bin/onnx2ncnn"
+fi
+
+echo
+if [ -f "$PREFIX/lib/cmake/ncnn/ncnnConfig.cmake" ]; then
+    echo "==> installed: find_package(ncnn) will succeed; WITH_GPU auto-enables."
+fi
+echo "==> rebuild the engine so it picks this up:"
+echo "    rm -rf concept_A/MediaFusionGCV/build"
+echo "    cmake -S concept_A/MediaFusionGCV -B concept_A/MediaFusionGCV/build"
+echo "    (expect the configure line: 'GPU inference: ncnn <ver> + Vulkan ENABLED')"
+echo "==> then convert the weights for the GPU path:  scripts/fetch-models.sh"

--- a/scripts/fetch-models.sh
+++ b/scripts/fetch-models.sh
@@ -35,9 +35,38 @@ fetch() {
 fetch "$YOLOV5N_URL" "$DEST/yolov5n.onnx"
 fetch "$LABELS_URL"  "$DEST/coco.names"
 
+# --- ncnn conversion (GPU / Vulkan detector) ------------------------------------
+# The Vulkan detector loads ncnn .param/.bin, not ONNX. This is NOT a plain
+# onnx2ncnn run: yolov5n.onnx is FP16 and its Detect head both break ncnn's Vulkan
+# backend (null weight_data in Convolution_vulkan::create_pipeline; null pipeline
+# in BinaryOp_vulkan). scripts/onnx-to-ncnn.sh does the working pipeline —
+# FP16->FP32 then pnnx — producing a Vulkan-safe model. Best-effort: it needs
+# python3 with onnx + pnnx (the helper sets up a venv if missing). The CPU detector
+# uses the .onnx directly and needs none of this, so a failure here is non-fatal.
+convert_ncnn() {
+    local stem="$1"
+    local onnx="$DEST/$stem.onnx"
+    [ -s "$onnx" ] || return 0
+    if [ -s "$DEST/$stem.param" ] && [ -s "$DEST/$stem.bin" ]; then
+        echo "==> $stem.param/.bin already present, skipping"
+        return 0
+    fi
+
+    local here; here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    echo "==> converting $stem -> ncnn (Vulkan-ready) via scripts/onnx-to-ncnn.sh"
+    if ! bash "$here/onnx-to-ncnn.sh" "$onnx" "$DEST"; then
+        echo "!! ncnn conversion failed/skipped for $stem -- the GPU (Vulkan) detector" >&2
+        echo "   stays unavailable until $stem.param/.bin exist; the CPU detector still works." >&2
+    fi
+}
+
+convert_ncnn "yolov5n"
+
 echo
 echo "==> models in $DEST:"
 ls -lh "$DEST"
 echo
 echo "Try it:  MediaFusionGCV then 'models', 'create camera app c', 'model 0 yolov5n',"
 echo "         'set-device 0 0 0', 'algos 0 detect', 'start 0', 'stats 0'"
+echo "GPU:     'accelerators' lists what was detected; 'accel 0 auto' (or vulkan)"
+echo "         before 'start' runs the forward pass on the Radeon when available."

--- a/scripts/fp16to32.py
+++ b/scripts/fp16to32.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Rewrite an FP16 ONNX graph as FP32.
+
+The published yolov5n.onnx is an FP16 graph. Feeding that straight through
+onnx2ncnn produces a model whose Convolution weight_data comes out null, which
+then SIGSEGVs in ncnn's Vulkan conv-pipeline creation (it loads fine on ncnn's
+CPU path, which is what made the bug so confusing). Converting to FP32 first —
+then letting pnnx emit the ncnn model — yields weights that ncnn's Vulkan
+backend can actually use. See scripts/onnx-to-ncnn.sh.
+
+Usage: fp16to32.py <in.onnx> <out.onnx>
+"""
+import sys
+import numpy as np
+import onnx
+from onnx import numpy_helper, TensorProto
+
+src, dst = sys.argv[1], sys.argv[2]
+m = onnx.load(src)
+g = m.graph
+F16, F32 = TensorProto.FLOAT16, TensorProto.FLOAT
+
+# 1) initializers (the weights) fp16 -> fp32
+for init in g.initializer:
+    if init.data_type == F16:
+        arr = numpy_helper.to_array(init).astype(np.float32)
+        init.CopyFrom(numpy_helper.from_array(arr, init.name))
+
+# 2) graph input/output/value_info tensor element types
+def fix(vis):
+    for vi in vis:
+        tt = vi.type.tensor_type
+        if tt.elem_type == F16:
+            tt.elem_type = F32
+fix(g.input); fix(g.output); fix(g.value_info)
+
+# 3) Cast-to-fp16 nodes -> cast to fp32, and any fp16 attribute tensors
+for node in g.node:
+    if node.op_type == "Cast":
+        for a in node.attribute:
+            if a.name == "to" and a.i == F16:
+                a.i = F32
+    for a in node.attribute:
+        if a.type == onnx.AttributeProto.TENSOR and a.t.data_type == F16:
+            arr = numpy_helper.to_array(a.t).astype(np.float32)
+            a.t.CopyFrom(numpy_helper.from_array(arr))
+
+onnx.save(m, dst)
+print("wrote", dst)

--- a/scripts/onnx-to-ncnn.sh
+++ b/scripts/onnx-to-ncnn.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Convert a (possibly FP16) YOLO ONNX into an ncnn model that runs on ncnn's
+# VULKAN backend — not just its CPU one.
+#
+# Why this is more than `onnx2ncnn`:
+#   * The published yolov5n.onnx is FP16. onnx2ncnn mishandles the FP16 weights,
+#     leaving Convolution weight_data null → SIGSEGV in ncnn's Vulkan
+#     Convolution_vulkan::create_pipeline (the same model loads fine on ncnn CPU).
+#   * yolov5's Detect head becomes raw BinaryOp layers under onnx2ncnn that ncnn's
+#     Vulkan BinaryOp path can't run (null pipeline in forward).
+#   pnnx, fed an FP32 graph, folds/optimises both away and emits a Vulkan-safe
+#   ncnn model. So: onnx --(fp16->fp32)--> pnnx --> <stem>.param/.bin.
+#
+# Needs python3 with onnx + pnnx. If they are not importable, a throwaway venv is
+# created (set MFGCV_VENV to reuse one). Best-effort: the CPU detector (cv::dnn on
+# the .onnx) does not need any of this.
+#
+# Usage: onnx-to-ncnn.sh <model.onnx> [out_dir] [WxH]     (default out_dir = onnx's dir, size 640x640)
+set -euo pipefail
+
+ONNX="$1"
+OUTDIR="${2:-$(cd "$(dirname "$ONNX")" && pwd)}"
+SIZE="${3:-640}"
+STEM="$(basename "$ONNX" .onnx)"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV="${MFGCV_VENV:-${TMPDIR:-/tmp}/mfgcv-convert-venv}"
+
+PY=python3
+if ! python3 -c 'import onnx, pnnx' >/dev/null 2>&1; then
+    if [ ! -x "$VENV/bin/pnnx" ]; then
+        echo "==> setting up conversion venv at $VENV (onnx + pnnx; downloads torch, a few hundred MB)"
+        python3 -m venv "$VENV"
+        "$VENV/bin/pip" install --quiet --upgrade pip
+        "$VENV/bin/pip" install --quiet onnx pnnx
+    fi
+    PY="$VENV/bin/python"
+fi
+PNNX="$(dirname "$PY")/pnnx"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+
+echo "==> $STEM: FP16 -> FP32"
+"$PY" "$HERE/fp16to32.py" "$ONNX" "$work/${STEM}_fp32.onnx"
+
+echo "==> $STEM: pnnx (FP32 ONNX -> ncnn, inputshape [1,3,$SIZE,$SIZE])"
+( cd "$work" && "$PNNX" "${STEM}_fp32.onnx" "inputshape=[1,3,$SIZE,$SIZE]" >/dev/null 2>&1 )
+
+p="$work/${STEM}_fp32.ncnn.param"
+b="$work/${STEM}_fp32.ncnn.bin"
+if [ -s "$p" ] && [ -s "$b" ]; then
+    cp "$p" "$OUTDIR/$STEM.param"
+    cp "$b" "$OUTDIR/$STEM.bin"
+    echo "==> wrote $OUTDIR/$STEM.param and $OUTDIR/$STEM.bin (Vulkan-ready)"
+else
+    echo "!! pnnx produced no ncnn output for $STEM" >&2
+    exit 1
+fi


### PR DESCRIPTION
# feat: ONNX object detection stage with live inference telemetry

Implements roadmap items 1 and 2: a YOLO-family object detector as a third entry in
the OpenCV chain, plus the telemetry that makes it observable from the console.

`algos-list` now returns `grayscale,canny,detect`. Selecting `detect` runs an ONNX
graph over each frame, draws labelled boxes in place, and reports latency and
detections over the control protocol.

## Two things worth reviewing carefully

**1. Inference does not run in the pad probe.**

A yolov5n forward pass costs ~55 ms on this CPU — far longer than a frame interval.
Running it inside the probe would convert every detection into pipeline
backpressure. `DetectorAlgorithm` instead hands a frame copy to a worker thread
when that worker is idle and overlays the newest completed result. The stream keeps
the camera's frame rate, boxes lag a frame or two, and `stats` reports
`inferred`/`skipped` separately — which is why FPS and INFERENCE_LATENCY are
independent readings in the UI rather than two views of one number.

The in-place-pad-probe invariant is preserved: buffers are still modified and
forwarded, never replaced, so `unixfdsink`'s memfd allocation negotiation is intact.

**2. This requires OpenCV 4.8+, which is not the apt version.**

Ubuntu 24.04 ships 4.6 and its ONNX importer cannot read current YOLO exports.
Verified, not assumed:

- `yolov5n.onnx` as published → `Unsupported data type: FLOAT16`
- after converting to FP32 → `Split` node in the detect head unsupported
- OpenCV 4.12 → reads the published FP16 file directly, output `1x25200x85`

`scripts/build-opencv.sh` builds 4.12 into `~/.local` — no root, trimmed module
list (~10 min), and the apt 4.6 stays installed and untouched (different sonames).
The engine's CMakeLists prepends that prefix to `PKG_CONFIG_PATH` itself, so
`cmake -S concept_A/MediaFusionGCV -B ...` needs no new flags. Only the engine
links OpenCV; the console is unaffected.

**CI impact:** the workflow now builds OpenCV on cache miss, with the install prefix
cached and the timeout raised 30 → 60 min. The first run after merge (or any
`OPENCV_VERSION` bump) pays the full build; every run after that restores from cache.

## Protocol additions

| Command | Reply |
|---|---|
| `models` | installed models with class count, input size, path |
| `model <id> [name]` | load a detector model; no name unloads it |
| `detect-params <id> <conf> <nms> [draw]` | thresholds and box overlay |
| `stats <id>` | latency, counters, and the last detections |

Bad model names are rejected at configure time (`LOAD_MODEL_ERR`), not silently
accepted and left idle at stream time.

## Console

Model picker and confidence slider on the Dashboard, both applied live mid-stream;
DETECTION_SUMMARY tiles; an INFERENCE_LATENCY chart on Analytics; detection changes
in the event log. The 1 Hz stats poll is deliberately kept off the wire log — it
would otherwise bury every other entry. GPU_ACCELERATION stays `PLANNED`: inference
is CPU-only, there is no CUDA on this rig, and OpenCV's OpenCL target needs an ICD
that is not guaranteed present.

## Verification

- Engine suites 14 → 22 tests, all passing; new `inference` suite skips its
  model-bound assertions when no weights are installed, which is the CI and
  fresh-clone state
- Canonical YOLOv5 result reproduced on `bus.jpg`: 4 people + bus, boxes
  pixel-accurate, per-class colours
- Live camera end-to-end: model loaded, 46 inferences at ~57 ms, detections
  decoded and reported
- `--selftest-stream` passes (1920x1080, zero-copy path intact);
  `--selftest-screenshot` renders all seven pages; screenshots regenerated

## Not included

Weights are gitignored — `scripts/fetch-models.sh` fetches `yolov5n.onnx` plus COCO
labels. A fresh clone builds and tests green without them.

RAW-vs-AI Compare still needs engine `tee` support and remains `PLANNED`.
