### PR TITLE
perf: unblock multi-camera streaming with MJPEG capture and a decoupled capture thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ interrupts operations; errors surface as log entries and tile badges.
 | **Daemon control** | `MediaFusionGCV --serve <socket>`: full text protocol (create / devices / set-device / algos / start / stop / delete / list), one connection, serialized commands |
 | **Daemon lifecycle** | Console auto-spawns the daemon if unreachable, restarts it (`REBOOT_CORE`) or shuts it down (`TERMINATE_PID`); crash → status LED + tiles fall back to `NO_SIGNAL` |
 | **Device manager** | Camera enumeration (raw V4L2 and PipeWire providers, same-node twins deduplicated) with per-device caps (resolution / format / framerate) selection; the source element is built from the selected device; only modes the CPU pipeline can negotiate are listed (DMABuf/`DMA_DRM` import is planned) |
+| **Capture formats** | Raw *and* **MJPEG** capture modes, labelled apart in the picker; an encoded mode gets a decoder (`jpegdec`, else `avdec_mjpeg`) spliced into the chain automatically. This is what makes several cameras on one USB bus viable — 720p YUYV is ~55 MB/s, so two of them do not fit on USB 2.0 and the second is starved. On the dev webcam it is also the difference between **1080p at 5 fps (raw, measured 4.5) and 1080p at 30 fps (MJPEG, measured 15.1 under office lighting)** |
 | **Multi-stream** | 2×2 multi-grid, one independent daemon pipeline per tile; a single camera can feed several tiles at once (PipeWire multiplexing) |
 | **Telemetry** | Real per-stream FPS & throughput (sink pad probe); real host telemetry — AMD GPU temperature, VRAM, fan, GPU busy %, CPU package temp (hwmon, 1 Hz) |
 | **Observability** | App-wide event log with level filters and CSV export, including the full control-protocol transcript |
 | **Theming** | Generated QSS from design tokens; runtime accent-hue switching |
-| **Verification** | `gstreamer-check` suite (4 suites, 25 tests) + built-in self-tests: offscreen screenshot tour and a full hardware-in-the-loop stream test; GitHub Actions builds, tests and renders every page on each push to `main` |
+| **Verification** | `gstreamer-check` suite (4 suites, 26 tests) + built-in self-tests: offscreen screenshot tour and a full hardware-in-the-loop stream test; `scripts/bench-capture.sh` measures engine throughput for one capture mode; GitHub Actions builds, tests and renders every page on each push to `main` |
 
 ### Planned
 
@@ -106,7 +107,7 @@ flowchart LR
         direction TB
         CTL["--serve control daemon<br/><i>text protocol over UDS</i>"]
         PM["PipelineManager stash"]
-        PIPE["v4l2src → capsfilter →<br/>OpenCV chain (pad probe) →<br/>unixfdsink"]
+        PIPE["v4l2src → queue → capsfilter →<br/>jpegdec (MJPEG modes) → videoconvert →<br/>OpenCV chain (pad probe) → unixfdsink"]
         CTL --- PM --- PIPE
     end
 
@@ -205,7 +206,10 @@ cmake -S concept_A/GuiMediaFusion -B concept_A/GuiMediaFusion/build
 cmake --build concept_A/GuiMediaFusion/build -j
 ```
 
-Binaries land in `concept_A/x64_debug/`.
+Binaries land in `concept_A/x64_debug/`. Both trees default to `RelWithDebInfo`
+(optimized, full symbols) — the per-frame code is this project's own, so an
+unoptimized build costs real frame rate. Pass `-DCMAKE_BUILD_TYPE=Debug` when you
+need to step through locals that optimization folds away.
 
 ### Run
 
@@ -236,14 +240,21 @@ QT_QPA_PLATFORM=offscreen ./concept_A/x64_debug/GUIMediaFusion --selftest-screen
 # Full hardware-in-the-loop check: daemon → camera → zero-copy socket → viewport,
 # exits 0 once frames are flowing
 ./concept_A/x64_debug/GUIMediaFusion --selftest-stream
+
+# Engine throughput for one capture mode (frames/s and drops, console not involved)
+scripts/bench-capture.sh 0 "1080p MJPEG"
 ```
+
+Measured numbers, the open performance work and the pipeline invariants that look
+like optimizations but break streaming live in
+[`docs/PERFORMANCE.md`](docs/PERFORMANCE.md).
 
 ## Repository layout
 
 ```
 concept_A/
 ├── MediaFusionGCV/          # engine: library, daemon/REPL executable, tests
-│   ├── PipelineManager.*    #   pipeline lifecycle, GMainLoop thread
+│   ├── PipelineManager.*    #   pipeline lifecycle, bus-polling thread
 │   ├── FrameProcessor.*     #   in-place OpenCV chain (pad probe)
 │   ├── Algorithms.*         #   Algorithm interface + factory (grayscale, canny, detect)
 │   ├── Detector.*           #   ONNX object detection on a worker thread
@@ -261,9 +272,12 @@ concept_A/
 models/                      # detector weights (gitignored, see scripts/)
 scripts/
 ├── build-opencv.sh          # OpenCV 4.8+ into ~/.local (apt's 4.6 is too old)
-└── fetch-models.sh          # yolov5n.onnx + COCO labels
+├── build-ncnn.sh            # ncnn + Vulkan into ~/.local (enables -DWITH_GPU)
+├── fetch-models.sh          # yolov5n.onnx + COCO labels, converted for ncnn
+└── bench-capture.sh         # engine throughput for one capture mode
 docs/
 ├── GUI_DESIGN.md            # console software design & design→engine feature matrix
+├── PERFORMANCE.md           # measured baselines, open optimizations, pipeline invariants
 ├── stitch/                  # browsable HTML design mockups (Stitch)
 └── screenshots/             # the images in this README
 ```

--- a/concept_A/GuiMediaFusion/CMakeLists.txt
+++ b/concept_A/GuiMediaFusion/CMakeLists.txt
@@ -6,6 +6,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Optimised by default, same reasoning as the backend's CMakeLists: the GUI runs
+# a colourspace convert and a GL upload per frame per tile.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+                 Debug Release RelWithDebInfo MinSizeRel)
+endif()
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+
 find_package(Qt6 COMPONENTS Core Gui Widgets REQUIRED)
 qt_standard_project_setup()
 

--- a/concept_A/GuiMediaFusion/StreamReceiver.cpp
+++ b/concept_A/GuiMediaFusion/StreamReceiver.cpp
@@ -26,10 +26,12 @@ bool StreamReceiver::start(const std::string& socketPath)
     // rather than accumulating delay; sync=false renders frames as they arrive.
     // glimagesink = GPU path via Mesa GL — swap for waylandsink / xvimagesink to
     // match the session if you prefer.
+    // videoconvert n-threads defaults to 1; 0 spreads the per-tile convert
+    // across cores, which matters once several tiles are live at once.
     const std::string desc =
         "unixfdsrc socket-path=" + socketPath + " ! "
         "queue max-size-buffers=3 leaky=downstream ! "
-        "videoconvert ! "
+        "videoconvert n-threads=0 ! "
         "glimagesink name=videosink sync=false";
 
     GError* err = nullptr;

--- a/concept_A/GuiMediaFusion/core/DeviceParser.cpp
+++ b/concept_A/GuiMediaFusion/core/DeviceParser.cpp
@@ -28,6 +28,14 @@ QString firstFraction(QString v)
     return QString::number(num / den, 'g', 4);
 }
 
+// The "Cap [N]: <media type>" header line the daemon prints for each cap.
+QString mediaType(const QString& block)
+{
+    const QRegularExpression re(QStringLiteral("^Cap \\[\\d+\\]: (\\S+)"));
+    const auto m = re.match(block);
+    return m.hasMatch() ? m.captured(1) : QString();
+}
+
 QString makeLabel(int index, const QString& block)
 {
     const QString w  = field(block, QStringLiteral("width"));
@@ -35,6 +43,12 @@ QString makeLabel(int index, const QString& block)
     QString fmt      = field(block, QStringLiteral("format"));
     fmt.remove('"');
     const QString fps = firstFraction(field(block, QStringLiteral("framerate")));
+
+    // An encoded mode carries no "format" field — its identity is the media
+    // type. Name it, so MJPEG and raw modes at the same geometry are tellable
+    // apart in the picker (they are very different in USB bandwidth).
+    if (fmt.isEmpty() && mediaType(block) == QStringLiteral("image/jpeg"))
+        fmt = QStringLiteral("MJPEG");
 
     QString label;
     if (!w.isEmpty() && !h.isEmpty())

--- a/concept_A/MediaFusionGCV/CMakeLists.txt
+++ b/concept_A/MediaFusionGCV/CMakeLists.txt
@@ -4,6 +4,18 @@ project(MediaFusionGCV VERSION 2.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Default to an optimized build. With no build type CMake passes no -O flag at
+# all, and the hottest code in this project is its own: the per-frame pad probe
+# and parseYoloOutput's scan over ~25k anchors per inference. RelWithDebInfo
+# keeps full symbols, so the debugger still works; pass -DCMAKE_BUILD_TYPE=Debug
+# explicitly when stepping through optimised-away locals is a problem.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+                 Debug Release RelWithDebInfo MinSizeRel)
+endif()
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+
 find_package(PkgConfig REQUIRED)
 
 pkg_search_module(gstreamer       REQUIRED IMPORTED_TARGET gstreamer-1.0>=1.4)

--- a/concept_A/MediaFusionGCV/GStreamerSource.cpp
+++ b/concept_A/MediaFusionGCV/GStreamerSource.cpp
@@ -3,7 +3,9 @@
 GStreamerSource::~GStreamerSource()
 {
     if (sourceElement) { gst_object_unref(sourceElement); sourceElement = nullptr; }
+    if (queue)         { gst_object_unref(queue);         queue         = nullptr; }
     if (capsFilter)    { gst_object_unref(capsFilter);    capsFilter    = nullptr; }
+    if (decoder)       { gst_object_unref(decoder);       decoder       = nullptr; }
     if (converter)     { gst_object_unref(converter);     converter     = nullptr; }
 }
 

--- a/concept_A/MediaFusionGCV/GStreamerSource.h
+++ b/concept_A/MediaFusionGCV/GStreamerSource.h
@@ -40,6 +40,15 @@ public:
     std::string getCapsStringAtIndex(int32_t deviceID, guint index);
 
     GstElement* sourceElement = nullptr;
+    // Decouples capture from everything downstream: the source's streaming task
+    // only dequeues from the driver and pushes here, so a slow colourspace
+    // convert or OpenCV stage can no longer stall the v4l2 buffer queue (which
+    // shows up as driver-level frame drops). Leaky downstream — under load the
+    // oldest frame is dropped rather than latency accumulating.
+    GstElement* queue         = nullptr;
     GstElement* capsFilter    = nullptr;
+    // Only present when the selected capture format is encoded (MJPEG); nullptr
+    // for a raw format, where the source already delivers video/x-raw.
+    GstElement* decoder       = nullptr;
     GstElement* converter     = nullptr;
 };

--- a/concept_A/MediaFusionGCV/GStreamerSourceCamera.cpp
+++ b/concept_A/MediaFusionGCV/GStreamerSourceCamera.cpp
@@ -1,5 +1,46 @@
 #include "GStreamerSourceCamera.h"
 
+namespace {
+
+// Capture formats the pipeline can consume. video/x-raw goes straight through;
+// image/jpeg (MJPEG) is decoded by the stage setCapsFilterElement() splices in.
+//
+// MJPEG matters for multi-camera work far more than it looks: a 1280x720 YUYV
+// stream is ~55 MB/s (~440 Mbit/s) on the wire, so two cameras cannot both fit
+// on one USB 2.0 bus (480 Mbit/s shared) and the second one is starved of
+// bandwidth by the UVC driver — which surfaces as heavy frame drops on camera 2.
+// The same modes in MJPEG are an order of magnitude smaller and fit comfortably.
+bool isSupportedMediaType(const char* mediaType)
+{
+    return g_strcmp0(mediaType, "video/x-raw") == 0
+        || g_strcmp0(mediaType, "image/jpeg")  == 0;
+}
+
+// Decoders tried, in order, for an MJPEG capture format.
+//
+// jpegdec (libjpeg-turbo) is first on purpose: it decodes into system memory,
+// which is what both the in-place BGR pad probe and unixfdsink's memfd allocator
+// need. vajpegdec would decode on the AMD GPU but hands back VA memory, and the
+// GL download path on this stack is the one that produced all-black frames
+// before (see accelSegmentFactories in PipelineManager.cpp) — worth revisiting
+// in a session that can validate it against a real camera.
+const char* const kJpegDecoders[] = { "jpegdec", "avdec_mjpeg" };
+
+GstElement* makeJpegDecoder()
+{
+    for (const char* factory : kJpegDecoders) {
+        if (GstElement* e = gst_element_factory_make(factory, "src-decoder")) {
+            std::cerr << "capture: MJPEG selected, decoding with " << factory << "\n";
+            return e;
+        }
+    }
+    std::cerr << "capture: MJPEG selected but no JPEG decoder is installed "
+                 "(tried jpegdec, avdec_mjpeg)\n";
+    return nullptr;
+}
+
+} // namespace
+
 GStreamerSourceCamera::GStreamerSourceCamera()
 {
 #ifdef  _WIN32
@@ -29,7 +70,9 @@ errorState GStreamerSourceCamera::getSourceDevices()
     if (!monitor)
         return errorState::CREATE_DEVICE_MONITOR_ERR;
 
-    GstCaps* caps = gst_caps_new_empty_simple("video/x-raw");
+    GstCaps* caps = gst_caps_new_empty();
+    gst_caps_append_structure(caps, gst_structure_new_empty("video/x-raw"));
+    gst_caps_append_structure(caps, gst_structure_new_empty("image/jpeg"));
     gst_device_monitor_add_filter(monitor, "Video/Source", caps);
     gst_caps_unref(caps);
 
@@ -82,7 +125,7 @@ void GStreamerSourceCamera::addDevicePropertie(const std::string& deviceName,
     guint total = deviceCaps ? gst_caps_get_size(deviceCaps) : 0;
     for (guint i = 0; i < total; ++i) {
         const GstStructure* s = gst_caps_get_structure(deviceCaps, i);
-        if (!s || g_strcmp0(gst_structure_get_name(s), "video/x-raw") != 0)
+        if (!s || !isSupportedMediaType(gst_structure_get_name(s)))
             continue;
         // Skip modes the CPU pipeline cannot negotiate: structures carrying a
         // special memory feature (PipeWire's memory:DMABuf with format=DMA_DRM)
@@ -216,6 +259,27 @@ errorState GStreamerSourceCamera::setCapsFilterElement(int32_t deviceId, int32_t
     GstCaps* capsPtr = gst_caps_from_string(caps.c_str());
     if (!capsPtr)
         return errorState::OBJECT_CREATION_ERR;
+
+    // An encoded format needs a decoder in the chain and a raw one must not have
+    // it, so the decision is rebuilt from scratch on every selection — switching
+    // a slot from MJPEG back to YUYV drops the decoder again. Only safe while the
+    // element is not yet in the pipeline bin, which is the case for the whole
+    // configure-then-start sequence the API expects.
+    const GstStructure* chosen  = gst_caps_get_structure(capsPtr, 0);
+    const bool          encoded = chosen
+                               && g_strcmp0(gst_structure_get_name(chosen), "image/jpeg") == 0;
+
+    if (decoder && !GST_OBJECT_PARENT(decoder)) {
+        gst_object_unref(decoder);
+        decoder = nullptr;
+    }
+    if (encoded && !decoder) {
+        decoder = makeJpegDecoder();
+        if (!decoder) {
+            gst_caps_unref(capsPtr);
+            return errorState::OBJECT_CREATION_ERR;
+        }
+    }
 
     g_object_set(capsFilter, "caps", capsPtr, NULL);
     gst_caps_unref(capsPtr);

--- a/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
+++ b/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
@@ -4,9 +4,14 @@
 #include "ModelRegistry.h"
 #include "AcceleratorRegistry.h"
 
+#include <opencv2/core.hpp>
+
+#include <algorithm>
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
 
@@ -14,9 +19,38 @@
 std::vector<PipelineManager*> pipelines;
 
 
+// How many cores OpenCV's internal pool may use. Left alone, OpenCV takes every
+// core for each cv::dnn::forward() — with N cameras running that is N*cores
+// runnable threads on `cores` cores, and the losers are the v4l2 capture threads,
+// which must never stall or the driver drops frames. Inference is already
+// asynchronous and frame-skipping (see DetectorAlgorithm), so it does not need
+// the whole machine; it needs to not evict capture. A quarter of the cores is the
+// default; MEDIAFUSION_CV_THREADS overrides it for benchmarking (0 = OpenCV's
+// own default, i.e. no cap).
+static void capOpenCVThreads()
+{
+	int threads = std::clamp(static_cast<int>(std::thread::hardware_concurrency()) / 4, 1, 4);
+
+	if (const char* env = std::getenv("MEDIAFUSION_CV_THREADS")) {
+		try {
+			const int requested = std::stoi(env);
+			if (requested > 0)      threads = requested;
+			else if (requested == 0) return;          // explicit opt-out: leave OpenCV alone
+		} catch (...) {
+			std::cerr << "MEDIAFUSION_CV_THREADS='" << env << "' is not a number; ignoring\n";
+		}
+	}
+
+	cv::setNumThreads(threads);
+	std::cerr << "opencv thread pool capped at " << threads << " (of "
+	          << std::thread::hardware_concurrency() << " cores)\n";
+}
+
 errorState mediaLib_GStreamerInit(int argc, char* argv[])
 {
 	gst_init(&argc, &argv);
+
+	capOpenCVThreads();
 
 	// Probe acceleration once, here, so the cost (creating a Vulkan instance to
 	// enumerate devices) is paid at startup and the detected set is ready for the

--- a/concept_A/MediaFusionGCV/PipelineManager.cpp
+++ b/concept_A/MediaFusionGCV/PipelineManager.cpp
@@ -33,8 +33,27 @@ PipelineManager::PipelineManager(SourceType srcType, SinkType snkType, const cha
     }
 
     if (source) {
+        source->queue      = gst_element_factory_make("queue",        "src-queue");
         source->capsFilter = gst_element_factory_make("capsfilter",   "src-capsfilter");
         source->converter  = gst_element_factory_make("videoconvert", "src-converter");
+
+        if (source->queue) {
+            // Three frames is enough to ride out a scheduling spike without
+            // adding visible latency (~100 ms at 30 fps). Bound on buffers only:
+            // the byte and time limits would otherwise trip first and block the
+            // capture thread, which is exactly what this queue exists to prevent.
+            g_object_set(source->queue,
+                "max-size-buffers", 3,
+                "max-size-bytes",   0,
+                "max-size-time",    static_cast<guint64>(0),
+                "leaky",            2,        // GST_QUEUE_LEAK_DOWNSTREAM: drop oldest
+                NULL);
+        }
+        if (source->converter) {
+            // n-threads defaults to 1, so the (per-camera) colourspace convert is
+            // single-threaded; 0 lets videoconvert scale it across cores.
+            g_object_set(source->converter, "n-threads", 0, NULL);
+        }
     }
 
     if (sink) {
@@ -42,7 +61,8 @@ PipelineManager::PipelineManager(SourceType srcType, SinkType snkType, const cha
     }
 
     if (!pipeline
-        || (source && (!source->sourceElement || !source->capsFilter || !source->converter))
+        || (source && (!source->sourceElement || !source->queue
+                       || !source->capsFilter || !source->converter))
         || (sink   && (!sink->sinkElement || !sink->converter)))
     {
         g_error("Failed to create pipeline elements");
@@ -300,6 +320,7 @@ errorState PipelineManager::buildPipeline()
 
     gst_bin_add_many(GST_BIN(pipeline),
         source->sourceElement,
+        source->queue,
         source->capsFilter,
         source->converter,
         sink->converter,
@@ -310,10 +331,17 @@ errorState PipelineManager::buildPipeline()
     // now holds the only reference.  Add an explicit ref so that source/sink
     // destructors can safely unref their own pointers without a double-free.
     gst_object_ref(source->sourceElement);
+    gst_object_ref(source->queue);
     gst_object_ref(source->capsFilter);
     gst_object_ref(source->converter);
     gst_object_ref(sink->converter);
     gst_object_ref(sink->sinkElement);
+
+    // Present only for an encoded capture format (MJPEG); same ownership rule.
+    if (source->decoder) {
+        gst_bin_add(GST_BIN(pipeline), source->decoder);
+        gst_object_ref(source->decoder);
+    }
 
     if (useProcessor) {
         gst_bin_add_many(GST_BIN(pipeline), processor->filterElement, NULL);
@@ -328,37 +356,40 @@ errorState PipelineManager::buildPipeline()
         m_gpuElements.push_back(e);
     }
 
-    struct LinkStep { GstElement* from; GstElement* to; const char* desc; };
-    std::vector<LinkStep> steps = {
-        { source->sourceElement, source->capsFilter, "source → src-capsfilter" },
+    // The chain in order, skipping the stages this configuration does not use.
+    // Everything is linked pairwise below, so an optional stage is added or left
+    // out in one place instead of branching over every possible link.
+    struct Stage { GstElement* element; const char* name; };
+    std::vector<Stage> chain = {
+        { source->sourceElement, "source"         },
+        { source->queue,         "src-queue"      },
+        { source->capsFilter,    "src-capsfilter" },
     };
 
-    // src-capsfilter → [GPU convert segment] → src-converter. The trailing
-    // videoconvert still guarantees exact BGR/system-memory for the pad probe,
-    // so the unixfdsink memfd contract is untouched whether or not the GPU
-    // segment is present.
-    if (!gpuSeg.empty()) {
-        steps.push_back({ source->capsFilter, gpuSeg.front(), "src-capsfilter → gpu-in" });
-        for (size_t i = 1; i < gpuSeg.size(); ++i)
-            steps.push_back({ gpuSeg[i - 1], gpuSeg[i], "gpu → gpu" });
-        steps.push_back({ gpuSeg.back(), source->converter, "gpu-out → src-converter" });
-    } else {
-        steps.push_back({ source->capsFilter, source->converter, "src-capsfilter → src-converter" });
-    }
+    // Encoded capture (MJPEG) has to be decoded before anything can look at
+    // pixels. Raw formats leave decoder == nullptr and the stage is skipped.
+    if (source->decoder)
+        chain.push_back({ source->decoder, "src-decoder" });
 
-    if (useProcessor) {
-        // Splice the BGR capsfilter in; its src-pad probe processes each buffer
-        // in place (see FrameProcessor), so downstream allocation stays intact.
-        steps.push_back({ source->converter,       processor->filterElement, "src-converter → fp-bgr" });
-        steps.push_back({ processor->filterElement, sink->converter,         "fp-bgr → sink-queue"    });
-    } else {
-        steps.push_back({ source->converter,    sink->converter,        "src-converter → sink-queue" });
-    }
-    steps.push_back({ sink->converter, sink->sinkElement, "sink-queue → sink" });
+    // [GPU convert segment] → src-converter. The trailing videoconvert still
+    // guarantees exact BGR/system-memory for the pad probe, so the unixfdsink
+    // memfd contract is untouched whether or not the GPU segment is present.
+    for (GstElement* e : gpuSeg)
+        chain.push_back({ e, "gpu" });
+    chain.push_back({ source->converter, "src-converter" });
 
-    for (auto& s : steps) {
-        if (!gst_element_link(s.from, s.to)) {
-            std::cerr << "Failed to link: " << s.desc << "\n";
+    // The BGR capsfilter's src-pad probe processes each buffer in place (see
+    // FrameProcessor), so downstream allocation stays intact.
+    if (useProcessor)
+        chain.push_back({ processor->filterElement, "fp-bgr" });
+
+    chain.push_back({ sink->converter,  "sink-queue" });
+    chain.push_back({ sink->sinkElement, "sink"      });
+
+    for (size_t i = 1; i < chain.size(); ++i) {
+        if (!gst_element_link(chain[i - 1].element, chain[i].element)) {
+            std::cerr << "Failed to link: " << chain[i - 1].name
+                      << " → " << chain[i].name << "\n";
             GstCaps* setCaps = nullptr;
             g_object_get(source->capsFilter, "caps", &setCaps, NULL);
             gchar* capsStr = setCaps ? gst_caps_to_string(setCaps) : nullptr;

--- a/concept_A/MediaFusionGCV/tests/test_device_enumeration.cpp
+++ b/concept_A/MediaFusionGCV/tests/test_device_enumeration.cpp
@@ -77,7 +77,9 @@ GST_END_TEST
 
 // PipeWire devices list DMABuf/DMA_DRM modes the CPU pipeline cannot use —
 // they must not appear in the capture-mode list (selecting one, e.g. the
-// multi-grid tiles' default cap 0, failed start with BUILD_PIPELINE_FAILED)
+// multi-grid tiles' default cap 0, failed start with BUILD_PIPELINE_FAILED).
+// MJPEG modes, by contrast, MUST survive: they are the only way two cameras
+// fit on one USB bus, and a decoder is spliced in for them at selection time.
 GST_START_TEST(test_dma_drm_modes_filtered)
 {
     GStreamerSourceCamera cam;
@@ -94,11 +96,53 @@ GST_START_TEST(test_dma_drm_modes_filtered)
 
     fail_unless(cam.devicesContainer.size() == before + 1, "device was not added");
     const auto* dev = cam.devicesContainer.back();
-    fail_unless(gst_caps_get_size(dev->deviceCapabilities) == 1,
-        "expected exactly 1 usable cap, got %u", gst_caps_get_size(dev->deviceCapabilities));
+    fail_unless(gst_caps_get_size(dev->deviceCapabilities) == 2,
+        "expected the YUY2 and MJPEG caps to survive, got %u",
+        gst_caps_get_size(dev->deviceCapabilities));
+
     const GstStructure* s0 = gst_caps_get_structure(dev->deviceCapabilities, 0);
     fail_unless(g_strcmp0(gst_structure_get_string(s0, "format"), "YUY2") == 0,
-        "surviving cap is not the YUY2 mode");
+        "first surviving cap is not the YUY2 mode");
+    const GstStructure* s1 = gst_caps_get_structure(dev->deviceCapabilities, 1);
+    fail_unless(g_strcmp0(gst_structure_get_name(s1), "image/jpeg") == 0,
+        "second surviving cap is not the MJPEG mode");
+}
+GST_END_TEST
+
+// Selecting an MJPEG capture mode must put a decoder in the chain, and going
+// back to a raw mode must take it out again.
+GST_START_TEST(test_mjpeg_cap_creates_decoder)
+{
+    GStreamerSourceCamera cam;
+    const size_t devIndex = cam.devicesContainer.size();
+
+    // setCapsFilterElement needs the capsfilter PipelineManager normally owns.
+    // The base destructor unrefs it, same as for a real pipeline.
+    cam.capsFilter = gst_element_factory_make("capsfilter", nullptr);
+    fail_unless(cam.capsFilter != nullptr, "capsfilter unavailable");
+
+    GstCaps* caps = gst_caps_from_string(
+        "video/x-raw, format=(string)YUY2, width=640, height=480, framerate=30/1; "
+        "image/jpeg, width=1920, height=1080, framerate=30/1");
+    fail_unless(caps != nullptr, "test caps failed to parse");
+    cam.addDevicePropertie("FakeCam", caps, nullptr);
+    gst_caps_unref(caps);
+
+    // The override is private on the camera; the interface is public on the base,
+    // which is how PipelineManager reaches it too.
+    GStreamerSource& src = cam;
+
+    errorState r = src.setCapsFilterElement(static_cast<int32_t>(devIndex), 0);
+    fail_unless(r == errorState::NO_ERR, "selecting the raw cap failed: %d", (int)r);
+    fail_unless(cam.decoder == nullptr, "a raw cap must not add a decoder");
+
+    r = src.setCapsFilterElement(static_cast<int32_t>(devIndex), 1);
+    fail_unless(r == errorState::NO_ERR, "selecting the MJPEG cap failed: %d", (int)r);
+    fail_unless(cam.decoder != nullptr, "an MJPEG cap must add a decoder");
+
+    r = src.setCapsFilterElement(static_cast<int32_t>(devIndex), 0);
+    fail_unless(r == errorState::NO_ERR, "reselecting the raw cap failed: %d", (int)r);
+    fail_unless(cam.decoder == nullptr, "switching back to raw must drop the decoder");
 }
 GST_END_TEST
 
@@ -113,6 +157,7 @@ Suite* device_enumeration_suite()
     tcase_add_test(tc, test_setdevice_oob_device_id);
     tcase_add_test(tc, test_setdevice_oob_cap_index);
     tcase_add_test(tc, test_dma_drm_modes_filtered);
+    tcase_add_test(tc, test_mjpeg_cap_creates_decoder);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,203 @@
+# Performance backlog
+
+Working record for the multi-camera performance effort. The list outlives any
+single session: each item says where the cost is, what it should buy, and how to
+tell whether it worked. **Update the status column in the same change that lands
+an item**, the way `README.md`'s feature tables are kept.
+
+Opened after a report that a second camera dropped heavily and that CPU, RAM and
+GPU use were all high.
+
+## How to measure
+
+```bash
+# which cap index is which
+printf 'create camera app t\ndevices 0\nquit\n' | ./concept_A/x64_debug/MediaFusionGCV
+
+# engine throughput for one capture mode (GUI not involved)
+scripts/bench-capture.sh <cap-index> [label] [algos-csv]
+
+# whole path including the console viewport
+./concept_A/x64_debug/GUIMediaFusion --selftest-stream
+```
+
+Record with every number: cap index and geometry, algorithm chain, accel
+selection, camera count, and build type. Frame rate alone is not a result —
+`dropped:` from the bench script and `skipped=` from `stats <id>` say whether the
+pipeline is shedding work to keep up.
+
+Two traps on this hardware, both hit while taking the baseline below:
+
+- **Auto-exposure sets the frame rate.** In office light this camera settles at
+  20 fps at 720p and 15 fps at 1080p regardless of what the caps advertise, and
+  it is stable to ±0.1 fps, so it reads exactly like a hard pipeline ceiling.
+  Compare modes under the same lighting, in one sitting.
+- **The camera arrives through PipeWire**, not `v4l2src` (`camera-source
+  element: pipewiresrc` in the daemon log). PipeWire does its own negotiation,
+  so v4l2-level reasoning about buffers and alt-settings does not transfer
+  directly.
+
+## Baseline
+
+Ryzen-class 12-core, Radeon RX 6750 XT (RADV), 16 GB, GStreamer 1.24.2,
+OpenCV 4.12, HP 320 FHD Webcam via PipeWire. One camera, no processing chain,
+after P1–P5. Measured 2026-07-25.
+
+| Capture mode | fps | dropped |
+|---|---|---|
+| MJPEG 1920×1080 | 15.1 | 0 |
+| MJPEG 1280×720 | 20.1 | 0 |
+| MJPEG 640×480 | 20.1 | 0 |
+| **raw YUY2 1920×1080** | **4.5** | 0 |
+
+The last row is the headline: this camera only advertises **5 fps** for raw
+1080p, against **30 fps** for MJPEG at the same geometry. Before P5 the raw mode
+was the only thing the engine could select, so 1080p was hard-capped at 5 fps for
+a single camera — before any question of a second one.
+
+**Not yet measured:** anything with two cameras attached, and anything with the
+`detect` stage live. Both are gaps in this baseline; fill them when the hardware
+is on the desk.
+
+## Landed
+
+| # | Item | Where |
+|---|---|---|
+| P1 | Default `CMAKE_BUILD_TYPE` to `RelWithDebInfo`. With no build type CMake passes no `-O` flag at all, and the hottest code is this project's own — the per-frame pad probe and `parseYoloOutput`'s scan over ~25k anchors per inference | both `CMakeLists.txt` |
+| P2 | `videoconvert n-threads=0`. It defaults to **1**, so the per-camera colourspace convert was single-threaded on both sides | `PipelineManager.cpp` ctor, `StreamReceiver.cpp` |
+| P3 | Cap OpenCV's thread pool at ¼ of the cores (`MEDIAFUSION_CV_THREADS` overrides; `0` disables the cap). Left alone OpenCV takes every core for each `forward()`, so N cameras meant N×cores runnable threads evicting the capture threads | `MediaFusionGCV_API.cpp` |
+| P4 | `queue max-size-buffers=3 leaky=downstream` directly after the source. The only queue used to be at the *end* of the chain, so capture, convert and every OpenCV stage ran in one thread and any hiccup stalled buffer dequeue — driver-level frame drops | `GStreamerSource.h`, `PipelineManager.cpp` |
+| P5 | **MJPEG capture.** Enumeration filtered everything except `video/x-raw`, so only uncompressed modes were selectable; a decoder (`jpegdec`, else `avdec_mjpeg`) is now spliced in when an encoded mode is chosen. 720p YUYV is ~55 MB/s (~440 Mbit/s) — two cameras cannot both fit on one USB 2.0 bus (480 Mbit/s shared) and the UVC driver starves the second one | `GStreamerSourceCamera.cpp`, `PipelineManager.cpp`, `DeviceParser.cpp` |
+
+## Backlog
+
+Payoff is an estimate from reading the code unless it says *measured*. Effort is
+S (a sitting), M (a session), L (multi-session or needs a design decision).
+
+| # | Item | Payoff | Effort | Status |
+|---|---|---|---|---|
+| P6 | Skip `videoconvert` + the BGR capsfilter entirely when no algorithms are active | high | S | open |
+| P7 | Letterbox straight to `inputSize` instead of `squarePadded()` | high | S | open |
+| P8 | Copy the detector job at input size, not full resolution | med | S | open |
+| P9 | Drop the OpenCL grayscale/canny path and the global `setUseOpenCL` | med | S | open |
+| P10 | Pick a sensible default capture mode instead of cap 0 | med | S | open |
+| P11 | Cache the device scan instead of re-running it per `PipelineManager` | med | M | open |
+| P12 | Share one detector/model across pipelines | high | L | open |
+| P13 | Carry YUYV/NV12 over the IPC socket, convert once at the sink | high | L | open |
+| P14 | Share one GL context/display across tiles | med | L | open |
+| P15 | Narrow `FrameProcessor::m_mutex` so `stats` does not block on a frame | low | S | open |
+| P16 | Keep watching the bus after the first message | low | S | open |
+| P17 | Revisit `sync=false` on both sinks — nothing paces or sheds on the clock | med | M | open |
+| P18 | VA-API hardware JPEG decode (`vajpegdec`) | med | M | open |
+| P19 | GPU colourspace segment — currently disabled, produced black frames | med | L | open |
+| P20 | Daemon control loop is a single-threaded serial accept | low | M | open |
+| P21 | Per-pipeline retained caps text dump | low | S | open |
+
+### Notes
+
+**P6 — skip the convert when nothing processes.** `source->converter`
+(`videoconvert`) is created in the `PipelineManager` constructor and always
+linked, and `FrameProcessor` forces `format=BGR` on its capsfilter. With no
+algorithms selected the whole convert is waste: the frame could travel to
+`unixfdsink` in the capture format. Watch the `unixfdsink` memfd allocation
+contract when changing what crosses the socket.
+
+**P7 — `squarePadded()`.** `InferenceBackend.cpp` allocates and zero-fills a
+`max(w,h)²` BGR Mat *per inference* — 1920×1920×3 = 11 MB — copies the frame in,
+then `blobFromImage` resizes it down to 640. Both the cv::dnn and the ncnn path
+go through it. Letterboxing directly at `inputSize` removes the allocation, the
+memset and the large-format resize.
+
+**P8 — detector job copy.** `DetectorAlgorithm::apply()` does
+`frame.copyTo(m_job)` on the streaming thread for every submitted frame — a full
+6.2 MB copy at 1080p. Combine with P7: downscale into the job buffer instead.
+
+**P9 — OpenCL filters.** The GPU path in `Algorithms.cpp` uploads the frame, runs
+two `cvtColor`s and downloads it — two PCIe round-trips of a 6 MB frame for work
+the file's own comment puts at ~1 ms on CPU. `wantOpenCL()` also calls
+`cv::ocl::setUseOpenCL(true)`, which is **process-global**: one camera choosing
+GPU flips OpenCL on for every pipeline in the daemon.
+
+**P10 — default capture mode.** `MultiGridPage::toggleSlot` hardcodes
+`capIndex = 0`, and cap 0 is whatever the driver happens to list first. On this
+camera that is now MJPEG 1080p30, which is a good default by luck rather than by
+choice. A policy — prefer encoded, then the highest advertised rate, then a
+resolution ceiling — should live in the engine so every client inherits it.
+Worth doing together with P11.
+
+**P11 — device scan per pipeline.** `GStreamerSourceCamera`'s constructor runs a
+full `GstDeviceMonitor` scan, so every `create` re-opens every camera node and
+re-enumerates every cap — including for the throwaway `__probe__` pipeline
+`BackendWorker::queryDevices()` creates and immediately deletes. Note the scan is
+also how a newly plugged camera is noticed, so a cache needs an invalidation
+story (`GstDeviceMonitor`'s added/removed bus messages are the natural source).
+
+**P12 — one detector across pipelines.** Today each pipeline owns a
+`DetectorAlgorithm` with its own `cv::dnn::Net`/`ncnn::Net`: N cameras means N
+copies of the weights in RAM/VRAM and N independent Vulkan nets. A shared engine
+with a submission queue would cut memory near-linearly and stop N cameras from
+each spawning a full-width forward pass. Design decision: per-camera fairness
+policy when one queue serves several streams.
+
+**P13 — stop shipping BGR over the socket.** BGR is forced for the whole IPC path
+by the FrameProcessor capsfilter. 1080p BGR is 6.22 MB/frame — two cameras at
+30 fps is ~373 MB/s of memfd traffic — and the console then does *another* CPU
+convert to RGBA before every GL upload. Carrying the capture format and
+converting once, in the GL sink, removes a full convert and most of the traffic.
+Interacts with P6 and with the in-place pad-probe contract below.
+
+**P14 — one GL context for all tiles.** Each `StreamReceiver` builds its own
+`glimagesink`, so a 2×2 grid is four GL contexts, four context threads and four
+texture pools. `gstglcontext` sharing via a `GstGLDisplay` on the pipeline bus is
+the supported route.
+
+**P15 — processor mutex.** `FrameProcessor::m_mutex` is held for the entire
+algorithm chain on every frame, and `inferenceStats()` takes the same mutex, so
+the 1 Hz stats poll blocks behind a frame's worth of OpenCV work. Jitter, not
+throughput — but it makes the telemetry lie about its own sample time.
+
+**P16 — bus loop.** `PipelineManager::startLoop` `break`s out of the poll loop
+after the *first* message, so one mid-stream error is logged and then nothing is
+watching the bus for the rest of the session.
+
+**P17 — pacing.** `unixfdsink sync=false` and `glimagesink sync=false` mean
+nothing in the chain paces or drops on the clock, and `sync=false` also neuters
+QoS events travelling upstream. It buys latency, which was the intent; the cost
+is that every frame is converted and uploaded no matter how far behind the
+console is. Needs a measurement of latency-vs-load before changing.
+
+**P18 — VA-API JPEG decode.** `vajpegdec` is present on this box and would move
+MJPEG decode onto the GPU, but it hands back VA memory and the download path is
+the one that produced all-black frames before (see `accelSegmentFactories`).
+Needs validation against a real camera before it can be a default. `jpegdec`
+(libjpeg-turbo, system memory) is the safe choice until then.
+
+**P19 — GPU colourspace segment.** `accelSegmentFactories()` returns `{}` on
+purpose: `glupload ! glcolorconvert ! gldownload` negotiated and streamed but
+delivered all-black frames to the BGR pad probe on this RADV/GL stack. The seam
+is in place. Largely subsumed by P13 if frames stop being converted to BGR.
+
+**P20 — control loop.** `runServer` accepts one client, serves it to completion,
+then accepts the next. Fine for one console; it is the blocker for a second
+client or for a remote operator.
+
+**P21 — retained caps text.** Every `deviceProperties` keeps a formatted text
+dump of every cap of every device for the life of the pipeline, and P5 roughly
+doubled the number of caps. Small per pipeline, but it scales with
+cameras × caps × pipelines for no reason.
+
+## Invariants
+
+Things that look like optimizations and break the pipeline. Each cost a debugging
+session already.
+
+- **The OpenCV stage must stay an in-place pad probe** on a BGR capsfilter. An
+  appsink→appsrc bridge allocates its own buffers, which breaks `unixfdsink`'s
+  memfd allocation negotiation — `GST_FLOW_ERROR`, "Internal data stream error".
+- **Capture modes carrying a non-system memory feature must stay filtered out**
+  (`memory:DMABuf` / `format=DMA_DRM` from PipeWire). The annotation is lost on
+  the way to the capsfilter and then matches no software element, so `start`
+  fails with `BUILD_PIPELINE_FAILED`.
+- **Pipeline ids shift after `delete`** — they are indexes into the engine's
+  stash. Clients must re-base, as `BackendService` does.
+- **A stopped pipeline cannot be restarted.** Create a fresh one per session.

--- a/scripts/bench-capture.sh
+++ b/scripts/bench-capture.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Measure end-to-end frame rate out of the engine for one capture mode.
+#
+# Spawns the daemon on a scratch control socket, deploys one pipeline, then
+# counts frames arriving on the video socket with fpsdisplaysink. Nothing is
+# left running and the GUI is not involved, so the number is the engine's own
+# throughput — see docs/PERFORMANCE.md for how to record a result.
+#
+#   scripts/bench-capture.sh <cap-index> [label] [algos-csv]
+#
+#   scripts/bench-capture.sh 0                      # cap 0, no processing
+#   scripts/bench-capture.sh 1 "720p" canny         # cap 1 with the canny stage
+#
+# Run `printf 'create camera app t\ndevices 0\nquit\n' | ./concept_A/x64_debug/MediaFusionGCV`
+# first to see which cap index is which.
+set -uo pipefail
+
+CAP="${1:?usage: bench-capture.sh <cap-index> [label] [algos-csv]}"
+LABEL="${2:-cap $CAP}"
+ALGOS="${3:-}"
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/concept_A/x64_debug/MediaFusionGCV"
+CTL="/tmp/mediafusiongcv-bench-$$.sock"
+LOG="$(mktemp -t mfg-bench-XXXXXX.log)"
+SECONDS_TO_SAMPLE="${BENCH_SECONDS:-12}"
+
+command -v socat      >/dev/null || { echo "need socat (apt install socat)"; exit 1; }
+command -v gst-launch-1.0 >/dev/null || { echo "need gst-launch-1.0"; exit 1; }
+[ -x "$BIN" ] || { echo "engine not built: $BIN"; exit 1; }
+
+cleanup() { [ -n "${DPID:-}" ] && kill "$DPID" 2>/dev/null; wait "${DPID:-}" 2>/dev/null; rm -f "$CTL"; }
+trap cleanup EXIT
+
+rm -f "$CTL"
+"$BIN" --serve "$CTL" >"$LOG" 2>&1 &
+DPID=$!
+for _ in $(seq 1 40); do [ -S "$CTL" ] && break; sleep 0.25; done
+[ -S "$CTL" ] || { echo "daemon did not come up; see $LOG"; exit 1; }
+
+send() { printf '%s\n' "$1" | timeout 20 socat -t5 - "UNIX-CONNECT:$CTL" 2>/dev/null | tr -d '\0'; }
+
+send "create camera app bench" >/dev/null
+send "set-device 0 0 $CAP"     >/dev/null
+[ -n "$ALGOS" ] && send "algos 0 $ALGOS" >/dev/null
+SOCK=$(send "start 0" | grep -o '/tmp/mediafusiongcv[^ ]*' | head -1)
+
+echo "=== $LABEL (cap $CAP)${ALGOS:+ algos=$ALGOS} ==="
+if [ -z "$SOCK" ]; then
+    echo "  START FAILED — daemon log:"
+    sed 's/^/    /' "$LOG"
+    exit 1
+fi
+
+sleep 1   # let caps negotiation and exposure settle
+timeout "$SECONDS_TO_SAMPLE" gst-launch-1.0 -v unixfdsrc socket-path="$SOCK" ! \
+    fpsdisplaysink text-overlay=false video-sink=fakesink sync=false 2>&1 \
+    | grep -oE 'rendered: [0-9]+, dropped: [0-9]+, current: [0-9.]+, average: [0-9.]+' \
+    | tail -1 | sed 's/^/  /'
+grep -E '^(capture|accel|detector|opencv):' "$LOG" | sed 's/^/  /'


### PR DESCRIPTION
# perf: unblock multi-camera streaming with MJPEG capture and a decoupled capture thread

Investigation of a report that a second camera dropped frames heavily and that
CPU, RAM and GPU use were all high. The threading suspicion turned out to be
wrong — every pipeline already gets its own independent thread set, cameras have
never shared one. The actual blocker was that **device enumeration filtered out
every `image/jpeg` mode**, so only uncompressed capture was ever selectable.

That matters twice over. 720p YUYV is ~55 MB/s (~440 Mbit/s), so two cameras
cannot both fit on one USB 2.0 bus (480 Mbit/s shared) and the UVC driver starves
the second one. And on the dev webcam it is not even a multi-camera problem:

| Capture mode | fps | dropped |
|---|---|---|
| MJPEG 1920×1080 | 15.1 | 0 |
| MJPEG 1280×720 | 20.1 | 0 |
| **raw YUY2 1920×1080** — the only option before | **4.5** | 0 |

The camera advertises **5 fps** for raw 1080p against **30 fps** for MJPEG at the
same geometry. 1080p was hard-capped at 5 fps for a *single* camera, before any
question of a second.

Four supporting fixes came out of reading the per-frame path.

## What changed

| Commit | Change |
|---|---|
| `ddc83e1` | Both trees default to `RelWithDebInfo`. There was no `-O` flag at all — neither `CMakeLists.txt` set `CMAKE_BUILD_TYPE`, and the hottest code is this project's own: the per-frame pad probe and `parseYoloOutput`'s scan over ~25k anchors per inference |
| `755eac1` | `queue max-size-buffers=3 leaky=downstream` directly after the source, and `videoconvert n-threads=0` on both sides of the socket |
| `b9e9e97` | OpenCV's thread pool capped at ¼ of the cores |
| `0cf297c` | MJPEG capture modes with an automatic decode stage |
| `275291a` | `docs/PERFORMANCE.md`, `scripts/bench-capture.sh`, README |

**The queue placement was the structural bug.** The only `queue` in the chain sat
at the *end*, so capture, colourspace convert and every OpenCV stage ran in
`v4l2src`'s streaming thread — any hiccup in the probe stalled buffer dequeue,
which the driver reports as dropped frames. The chain is now
`v4l2src → queue → capsfilter → [jpegdec] → videoconvert → [fp-bgr probe] → queue → unixfdsink`.

**`videoconvert n-threads` defaults to 1**, confirmed against GStreamer 1.24.2 on
this box — the per-camera convert was single-threaded.

**OpenCV took every core for each `forward()`.** Nothing called
`cv::setNumThreads`, so N cameras meant N×cores runnable threads, and the ones
losing the race were the capture threads that must never stall. Capped at ¼ of
the cores, overridable with `MEDIAFUSION_CV_THREADS` (`0` restores OpenCV's
default). Inference is already asynchronous and frame-skipping, so it does not
need the whole machine — it needs to not evict capture.

`buildPipeline()` was also reworked from ad-hoc pairwise links into a single
ordered chain vector, so an optional stage (decoder, GPU segment, processor) is
added in one place instead of branching over every possible link.

## Worth reviewing carefully

**1. One existing test was changed, not just added to.**

`test_dma_drm_modes_filtered` asserted that `image/jpeg` caps get filtered out —
exactly the behaviour this PR reverses. It now asserts MJPEG *survives* while
`DMA_DRM` is still filtered, which was the test's real purpose.
`test_mjpeg_cap_creates_decoder` is new and covers the splice in both directions
(raw → no decoder, MJPEG → decoder, back to raw → decoder dropped).

**2. `jpegdec` over `vajpegdec`, deliberately.**

`vajpegdec` is present on this box and would move MJPEG decode onto the GPU, but
it hands back VA memory — and the download path is the one that produced
all-black frames in the GPU colour-convert work (`accelSegmentFactories`).
`jpegdec` (libjpeg-turbo) decodes into system memory, which is what both the
in-place BGR pad probe and `unixfdsink`'s memfd allocator need. `avdec_mjpeg` is
the fallback. Hardware JPEG decode is logged as P18, not attempted here.

**3. Two changes slightly outside the stated scope, both load-bearing.**

The console's `videoconvert` got `n-threads=0` too — same fix, other side of the
socket. And `DeviceParser` now labels MJPEG modes: without it, MJPEG and raw caps
at the same geometry are indistinguishable in the picker, which would ship the
feature unusable.

**4. `MultiGridPage` still hardcodes cap 0.**

Not touched here. On this camera cap 0 is now MJPEG 1080p30, so the grid default
improved by luck rather than by choice. A real capture-mode policy belongs in the
engine — logged as P10.

## Testing

- `gstreamer-check`: **26/26**, including the two enumeration tests above.
- `--selftest-stream`: passes end to end at 1920×1080 over the MJPEG path.
- `scripts/bench-capture.sh` across four capture modes — the table above; the
  daemon log confirms `capture: MJPEG selected, decoding with jpegdec`.

**Not verified:** anything with two cameras attached, and anything with the
`detect` stage live. Only one camera was available. Both gaps are marked in the
baseline in `docs/PERFORMANCE.md` rather than papered over.

Two traps that skew measurements on this hardware, both hit while taking the
baseline and both now documented: the webcam's **auto-exposure sets the frame
rate** in office light (720p and 480p both pin to exactly 20.05 fps — it reads
like a hard pipeline ceiling but isn't), and the camera arrives through
**`pipewiresrc`, not `v4l2src`**, so v4l2-level reasoning about buffers and USB
alt-settings does not transfer directly.

## Follow-ups

`docs/PERFORMANCE.md` is the working record for this effort — P1–P5 landed here,
**P6–P21 are open**, each with where the cost is, expected payoff, effort and how
to verify. It also carries an **Invariants** section for the things that look
like optimizations and break streaming (the in-place pad probe, `DMA_DRM`
filtering, shifting pipeline ids).

Highest-value remaining items:

- **P6** — skip `videoconvert` and the BGR capsfilter entirely when no algorithms
  are active; today a raw passthrough still pays a full colourspace convert.
- **P7** — `squarePadded()` allocates and zero-fills an 11 MB Mat per inference at
  1080p, then resizes it down to 640. Letterbox straight to `inputSize`.
- **P13** — stop carrying BGR over the IPC socket (6.22 MB/frame; two cameras at
  30 fps is ~373 MB/s) and convert once in the GL sink.

## Base branch

Branched from `feat/gpu-acceleration`, which is not yet in `main`. Against `main`
this shows 21 commits — the top 5 are this work, the other 16 are the unmerged
GPU-acceleration series. Either merge that one first, or review this one with
`feat/gpu-acceleration` as the base.