### PR TITLE
feat: algorithm registry with self-describing parameters, and the first motion stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@
 #     control protocol).
 #   * OpenCV comes from source, not apt: the detector needs 4.8+ to import
 #     current YOLO ONNX exports and 24.04 ships 4.6. The install prefix is
-#     cached, so only the first run (or an OPENCV_VERSION bump) pays for it.
+#     cached, and the cache key hashes the build script — a version bump or a
+#     changed module list rebuilds, everything else hits the cache.
 
 name: CI
 
@@ -49,7 +50,10 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.local
-          key: opencv-${{ env.OPENCV_VERSION }}-ubuntu-24.04
+          # The script's hash is part of the key: BUILD_LIST lives in there, and
+          # a cache built before a module was added would otherwise be restored
+          # and fail the engine build on a missing header.
+          key: opencv-${{ env.OPENCV_VERSION }}-${{ hashFiles('scripts/build-opencv.sh') }}-ubuntu-24.04
 
       - name: Build OpenCV from source
         if: steps.opencv-cache.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ interrupts operations; errors surface as log entries and tile badges.
 | Area | What works |
 |---|---|
 | **Streaming** | Camera → viewport, end-to-end: `create → set-device → algos → start`, frames over a per-stream zero-copy unixfd socket into an embedded GL viewport |
-| **Processing chain** | Runtime-selectable OpenCV algorithms (`grayscale`, `canny`, `detect`) applied in place via a pad probe — toggled live from the console |
+| **Processing chain** | Runtime-selectable OpenCV algorithms (`grayscale`, `canny`, `framediff`, `detect`) applied in place via a pad probe — toggled live from the console |
+| **Algorithm parameters** | Each stage describes its own knobs (`algo-params`); the console generates sliders/toggles from that schema and retunes a running stream with `algo-set` |
+| **Motion detection** | `framediff` — temporal difference against a running average of the scene, with sensitivity, background decay and overlay/mask/heat rendering |
 | **AI inference** | YOLO-family ONNX object detection (`detect`) through OpenCV DNN: model picker and confidence slider in the console, boxes drawn into the frame, model swappable mid-stream. Inference runs on a worker thread and the probe overlays the newest result, so detection cost never throttles the stream |
 | **Inference telemetry** | Real per-pipeline detector stats over the control protocol (`stats <id>`) — latency chart, TOTAL_OBJECTS / AVG_CONFIDENCE tiles, and detections in the event log |
 | **Acceleration** | Backends auto-detected at daemon start (CPU / Vulkan / CUDA) and reported over the protocol (`accelerators`); the console renders a capability-driven selector — only detected engines are offered, `AUTO` by default, CPU when no GPU. A per-deploy CPU/GPU choice threads through the pipeline (`accel <id> <sel>`) and always resolves to a runnable backend. **The YOLO detector runs on the GPU via ncnn + Vulkan** behind an `IInferenceBackend` seam — validated on a Radeon RX 6700-series (RADV): **≈24 ms/frame vs ≈57 ms on CPU** for yolov5n at 640² (~2.4×). Enabled by `scripts/build-ncnn.sh` (`-DWITH_GPU`); the weights are converted FP16→FP32→pnnx by `scripts/fetch-models.sh` (plain `onnx2ncnn` yields a graph that crashes ncnn's Vulkan path). Colourspace convert stays on the CPU (≈1 ms). CUDA is a compiled placeholder for a future NVIDIA card |
@@ -152,8 +154,11 @@ interactively: run the engine without arguments for a REPL, or
 | `create <src> <snk> <name>` | `OK id=N` | Allocate a pipeline (e.g. `create camera app cam0`) |
 | `devices <id>` | device & caps listing | Enumerate V4L2 devices with all capture modes |
 | `set-device <id> <dev> <cap>` | `OK` | Bind a device + capture mode to the source |
-| `algos-list` | `OK grayscale,canny,detect` | Available processing algorithms |
-| `algos <id> <csv>` | `OK` | Set the processing chain (empty CSV disables) |
+| `algos-list` | `OK grayscale,canny,framediff,detect` | Available processing algorithms |
+| `algos <id> <csv>` | `OK` | Set the processing chain (empty CSV disables; an unknown name is rejected) |
+| `algo-params <algo>` | parameter schema | Describe an algorithm's knobs, enough to build a control from |
+| `algo-set <id> <algo> <k=v,…>` | `OK` | Tune an algorithm (e.g. `algo-set 0 canny low=90`); values are clamped |
+| `algo-get <id> <algo>` | `OK <k=v,…>` | Current parameter values |
 | `models` | model listing | Detector models installed in `models/` |
 | `model <id> [name]` | `OK <name>` | Load a detector model (no name unloads it) |
 | `detect-params <id> <conf> <nms> [draw]` | `OK` | Detector thresholds and box overlay |
@@ -256,7 +261,9 @@ concept_A/
 ├── MediaFusionGCV/          # engine: library, daemon/REPL executable, tests
 │   ├── PipelineManager.*    #   pipeline lifecycle, bus-polling thread
 │   ├── FrameProcessor.*     #   in-place OpenCV chain (pad probe)
-│   ├── Algorithms.*         #   Algorithm interface + factory (grayscale, canny, detect)
+│   ├── Algorithms.*         #   Algorithm registry: one table drives the factory,
+│   │                        #   the name list and the parameter schemas
+│   ├── AlgorithmParam.*     #   Parameter descriptor a client builds a control from
 │   ├── Detector.*           #   ONNX object detection on a worker thread
 │   ├── ModelRegistry.*      #   discovery of models/ weights + labels
 │   ├── GStreamerSink*.??    #   screen (autovideosink) & app (unixfdsink) sinks

--- a/concept_A/GuiMediaFusion/core/BackendService.cpp
+++ b/concept_A/GuiMediaFusion/core/BackendService.cpp
@@ -106,7 +106,44 @@ void BackendWorker::queryAlgorithms()
         for (const QString& a : csv.split(',', Qt::SkipEmptyParts))
             algos << a.trimmed();
     }
+    // Schemas first, algorithmsReady last. A schema never changes for a given
+    // daemon, so it is fetched once here rather than per checkbox — and the
+    // pages build their controls inside their algorithmsChanged handler, so the
+    // cache has to be filled before that signal lands.
+    for (const QString& a : algos) {
+        QVector<AlgorithmParamSpec> params;
+        QString                     summary;
+        if (cmd(QStringLiteral("algo-params %1").arg(a), reply))
+            inferenceparser::parseAlgorithmParams(reply, summary, params);
+        // Emitted even with no knobs: the summary is worth having on its own,
+        // and it is what the checkbox tooltip is built from.
+        emit algorithmParamsReady(a, summary, params);
+    }
+
     emit algorithmsReady(algos);
+}
+
+// "low=90,high=200" — the wire form of one algorithm's values. Fixed precision
+// rather than shortest-round-trip so the log line is stable to read.
+static QString paramCsv(const QVariantMap& values)
+{
+    QStringList pairs;
+    for (auto it = values.constBegin(); it != values.constEnd(); ++it)
+        pairs << QStringLiteral("%1=%2").arg(it.key()).arg(it.value().toDouble(), 0, 'f', 3);
+    return pairs.join(QLatin1Char(','));
+}
+
+void BackendWorker::applyAlgorithmParams(int sessionId, const QString& algo,
+                                         const QVariantMap& values)
+{
+    if (values.isEmpty() || !m_sessions.contains(sessionId))
+        return;
+
+    QString reply;
+    const QString line = QStringLiteral("algo-set %1 %2 %3")
+                             .arg(m_sessions.value(sessionId)).arg(algo, paramCsv(values));
+    if (!cmd(line, reply) || !reply.startsWith(QStringLiteral("OK")))
+        emit wire(AppLog::Warn, QStringLiteral("algo-set %1 rejected: %2").arg(algo, reply));
 }
 
 void BackendWorker::queryModels()
@@ -180,7 +217,8 @@ void BackendWorker::pollStats()
 void BackendWorker::deploy(int sessionId, int deviceIndex, int capIndex,
                            const QString& algosCsv, bool screenSink, const QString& name,
                            const QString& detectorModel, double confidence, double nms,
-                           bool drawBoxes, const QString& accelSelection)
+                           bool drawBoxes, const QString& accelSelection,
+                           const AlgorithmSettings& algoParams)
 {
     const long id = createPipeline(QStringLiteral("camera"),
                                    screenSink ? QStringLiteral("screen") : QStringLiteral("app"),
@@ -219,6 +257,17 @@ void BackendWorker::deploy(int sessionId, int deviceIndex, int capIndex,
             emit detectorApplied(sessionId, true, detectorModel);
         else
             emit detectorApplied(sessionId, false, detail);
+    }
+
+    // Tuning before the chain, for the same reason as the model above: the
+    // engine remembers it per pipeline and replays it as each stage is built,
+    // so a stage never runs a frame on defaults the operator has changed.
+    for (auto it = algoParams.constBegin(); it != algoParams.constEnd(); ++it) {
+        if (it.value().isEmpty())
+            continue;
+        if (!cmd(QStringLiteral("algo-set %1 %2 %3").arg(id).arg(it.key(), paramCsv(it.value())), reply)
+            || !reply.startsWith(QStringLiteral("OK")))
+            emit wire(AppLog::Warn, QStringLiteral("algo-set '%1' rejected: %2").arg(it.key(), reply));
     }
 
     // Always send algos — an empty csv explicitly disables processing.
@@ -314,6 +363,13 @@ BackendService::BackendService(QObject* parent)
         logInfo("CTL", QStringLiteral("processing algorithms: %1")
                            .arg(a.isEmpty() ? QStringLiteral("(none)") : a.join(", ")));
         emit algorithmsChanged(a);
+    });
+    connect(m_worker, &BackendWorker::algorithmParamsReady, this,
+            [this](const QString& algo, const QString& summary,
+                   const QVector<AlgorithmParamSpec>& params) {
+        m_algorithmParams.insert(algo, params);
+        m_algorithmSummaries.insert(algo, summary);
+        emit algorithmParamsChanged(algo, params);
     });
     connect(m_worker, &BackendWorker::sessionStarted, this,
             [this](int id, const QString& sock, const QString& desc) {
@@ -572,9 +628,18 @@ int BackendService::deploy(const DeploySpec& spec)
     QMetaObject::invokeMethod(m_worker, [w = m_worker, sessionId, spec] {
         w->deploy(sessionId, spec.deviceIndex, spec.capIndex, spec.algosCsv,
                   spec.screenSink, spec.name, spec.detectorModel,
-                  spec.confidence, spec.nms, spec.drawBoxes, spec.accelSelection);
+                  spec.confidence, spec.nms, spec.drawBoxes, spec.accelSelection,
+                  spec.algoParams);
     }, Qt::QueuedConnection);
     return sessionId;
+}
+
+void BackendService::setAlgorithmParams(int sessionId, const QString& algo,
+                                        const QVariantMap& values)
+{
+    QMetaObject::invokeMethod(m_worker, [w = m_worker, sessionId, algo, values] {
+        w->applyAlgorithmParams(sessionId, algo, values);
+    }, Qt::QueuedConnection);
 }
 
 void BackendService::setDetector(int sessionId, const QString& model,

--- a/concept_A/GuiMediaFusion/core/BackendService.h
+++ b/concept_A/GuiMediaFusion/core/BackendService.h
@@ -20,13 +20,20 @@
 #include "InferenceTypes.h"
 
 #include <QHash>
+#include <QMap>
 #include <QObject>
 #include <QProcess>
 #include <QStringList>
 #include <QThread>
+#include <QVariantMap>
 
 class ControlClient;
 class QTimer;
+
+// Tuning for a whole chain: algorithm name → its parameter values. Carried in a
+// DeploySpec so the operator's settings are applied with the chain rather than
+// after it, and re-sent when a control moves on a live session.
+using AlgorithmSettings = QMap<QString, QVariantMap>;
 
 // Runs on the worker thread; owns the blocking socket client.
 class BackendWorker : public QObject
@@ -45,7 +52,8 @@ public slots:
     void deploy(int sessionId, int deviceIndex, int capIndex,
                 const QString& algosCsv, bool screenSink, const QString& name,
                 const QString& detectorModel, double confidence, double nms, bool drawBoxes,
-                const QString& accelSelection);
+                const QString& accelSelection, const AlgorithmSettings& algoParams);
+    void applyAlgorithmParams(int sessionId, const QString& algo, const QVariantMap& values);
     void applyDetector(int sessionId, const QString& model,
                        double confidence, double nms, bool drawBoxes);
     void pollStats();                          // one `stats` per live session
@@ -57,6 +65,8 @@ signals:
     void connectedChanged(bool ok, const QString& socketPath);
     void devicesReady(bool ok, const QVector<DeviceInfo>& devices);
     void algorithmsReady(const QStringList& algorithms);
+    void algorithmParamsReady(const QString& algo, const QString& summary,
+                              const QVector<AlgorithmParamSpec>& params);
     void modelsReady(const QVector<DetectorModel>& models);
     void acceleratorsReady(const QVector<AcceleratorOption>& accelerators);
     void detectorApplied(int sessionId, bool ok, const QString& detail);
@@ -101,6 +111,11 @@ public:
         double  nms         = 0.45;
         bool    drawBoxes   = true;
 
+        // Per-algorithm tuning, applied before `algos` so a stage starts on the
+        // operator's values rather than its defaults. Algorithms absent from the
+        // map simply keep their defaults.
+        AlgorithmSettings algoParams;
+
         // Acceleration backend for this session: "auto"/"cpu"/"vulkan"/"cuda".
         // Sent as `accel <id> <sel>` before start; the daemon resolves AUTO and
         // falls back to CPU for anything unavailable, so a stale pick never fails.
@@ -129,6 +144,16 @@ public:
 
     const QVector<DeviceInfo>& devices() const      { return m_devices; }
     const QStringList& algorithms() const           { return m_algorithms; }
+
+    // Schema for one algorithm, empty until the daemon has answered (the
+    // schemas are fetched once, right after `algos-list`) or if it has no knobs.
+    QVector<AlgorithmParamSpec> algorithmParams(const QString& algo) const
+    { return m_algorithmParams.value(algo); }
+
+    // One-line description of what the stage does, for a control's tooltip.
+    QString algorithmSummary(const QString& algo) const
+    { return m_algorithmSummaries.value(algo); }
+
     const QVector<DetectorModel>& models() const    { return m_models; }
     const QVector<AcceleratorOption>& accelerators() const { return m_accelerators; }
 
@@ -149,6 +174,10 @@ public:
     void setDetector(int sessionId, const QString& model,
                      double confidence, double nms, bool drawBoxes);
 
+    // Retune an algorithm on a running session. Values are clamped by the
+    // engine, so a control can send whatever its widget produces.
+    void setAlgorithmParams(int sessionId, const QString& algo, const QVariantMap& values);
+
     static QString defaultSocketPath();
     static QString defaultBinaryPath();
 
@@ -156,6 +185,8 @@ signals:
     void daemonStateChanged(BackendService::DaemonState state);
     void devicesChanged(const QVector<DeviceInfo>& devices);
     void algorithmsChanged(const QStringList& algorithms);
+    // Emitted once per algorithm as its schema arrives; pages build controls here.
+    void algorithmParamsChanged(const QString& algo, const QVector<AlgorithmParamSpec>& params);
     void sessionStarted(int sessionId, const QString& videoSocket, const QString& description);
     void sessionStopped(int sessionId);
     void sessionFailed(int sessionId, const QString& error);
@@ -191,6 +222,8 @@ private:
 
     QVector<DeviceInfo>    m_devices;
     QStringList            m_algorithms;
+    QHash<QString, QVector<AlgorithmParamSpec>> m_algorithmParams;
+    QHash<QString, QString>                     m_algorithmSummaries;
     QVector<DetectorModel> m_models;
     QVector<AcceleratorOption> m_accelerators;
     QString                m_accelSelection = QStringLiteral("auto");

--- a/concept_A/GuiMediaFusion/core/InferenceTypes.cpp
+++ b/concept_A/GuiMediaFusion/core/InferenceTypes.cpp
@@ -72,6 +72,47 @@ bool inferenceparser::parseAccelerators(const QString& reply, QVector<Accelerato
     return true;
 }
 
+bool inferenceparser::parseAlgorithmParams(const QString& reply, QString& summary,
+                                           QVector<AlgorithmParamSpec>& out)
+{
+    out.clear();
+    summary.clear();
+    if (!reply.startsWith(QLatin1String("OK")))
+        return false;
+
+    const QStringList lines = reply.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const QString& raw : lines) {
+        const QString line = raw.trimmed();
+        if (line.startsWith(QLatin1String("summary="))) {
+            summary = tailValue(line, QStringLiteral("summary"));
+            continue;
+        }
+        if (!line.startsWith(QLatin1String("key=")))
+            continue;
+
+        const QStringList  tokens = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        AlgorithmParamSpec p;
+        p.key  = value(tokens, QStringLiteral("key"));
+        p.type = value(tokens, QStringLiteral("type"));
+        p.min  = value(tokens, QStringLiteral("min")).toDouble();
+        p.max  = value(tokens, QStringLiteral("max")).toDouble();
+        p.step = value(tokens, QStringLiteral("step")).toDouble();
+        p.def  = value(tokens, QStringLiteral("default")).toDouble();
+
+        // Pipe-separated to keep the field one token; empty for a non-enum.
+        const QString choices = value(tokens, QStringLiteral("choices"));
+        if (!choices.isEmpty())
+            p.choices = choices.split(QLatin1Char('|'), Qt::SkipEmptyParts);
+
+        // Label last on the line, because it is the one field with spaces in it.
+        p.label = tailValue(line, QStringLiteral("label"));
+
+        if (!p.key.isEmpty())
+            out.push_back(p);
+    }
+    return true;
+}
+
 bool inferenceparser::parseStats(const QString& reply, InferenceSnapshot& snapshot)
 {
     snapshot = InferenceSnapshot{};

--- a/concept_A/GuiMediaFusion/core/InferenceTypes.h
+++ b/concept_A/GuiMediaFusion/core/InferenceTypes.h
@@ -14,6 +14,7 @@
 
 #include <QMetaType>
 #include <QString>
+#include <QStringList>
 #include <QVector>
 
 struct DetectorModel {
@@ -29,6 +30,23 @@ struct AcceleratorOption {
     QString backend;              // "cpu" / "vulkan" / "cuda"
     QString device;               // human-readable device, "" when none
     bool    available = false;    // usable on this host with this build
+};
+
+// One tunable knob from the daemon's `algo-params <algo>` reply. The console
+// builds a control from the descriptor alone and never has to know which
+// algorithm it belongs to, so a stage added to the engine gets its controls in
+// the UI without a GUI change.
+//
+//   key=low type=int min=0 max=255 step=1 default=80 choices= label=LOW THRESHOLD
+struct AlgorithmParamSpec {
+    QString     key;                  // wire name, what `algo-set` takes
+    QString     label;                // caption
+    QString     type;                 // "int" / "float" / "bool" / "enum"
+    double      min  = 0.0;
+    double      max  = 1.0;
+    double      step = 0.01;
+    double      def  = 0.0;
+    QStringList choices;              // enum only, indexed by the value
 };
 
 struct DetectionBox {
@@ -63,6 +81,12 @@ bool parseStats(const QString& reply, InferenceSnapshot& snapshot);
 // Parses the `accelerators` reply (lines: backend=… available=0|1 device=…).
 // True when the reply started with "OK".
 bool parseAccelerators(const QString& reply, QVector<AcceleratorOption>& out);
+
+// Parses the `algo-params <algo>` reply into the one-line summary and the knob
+// list. True when the reply started with "OK"; an empty list is normal — it
+// means the algorithm has no knobs, which is not the same as it not existing.
+bool parseAlgorithmParams(const QString& reply, QString& summary,
+                          QVector<AlgorithmParamSpec>& out);
 
 } // namespace inferenceparser
 

--- a/concept_A/GuiMediaFusion/pages/DashboardPage.cpp
+++ b/concept_A/GuiMediaFusion/pages/DashboardPage.cpp
@@ -329,15 +329,55 @@ void DashboardPage::onAlgorithms(const QStringList& algos)
         delete item;
     }
     m_algoBoxes.clear();
+    m_algoPanels.clear();
     if (algos.isEmpty()) {
         host->layout()->addWidget(new QLabel(QStringLiteral("no algorithms reported"), host));
         return;
     }
     for (const QString& a : algos) {
         auto* cb = new QCheckBox(a.toUpper(), host);
+        cb->setToolTip(m_service->algorithmSummary(a));
         m_algoBoxes.append(cb);
         host->layout()->addWidget(cb);
+
+        // Controls for whatever knobs this algorithm declares, hidden until the
+        // stage is actually selected so the panel does not fill with sliders
+        // for stages that are switched off.
+        const QVector<AlgorithmParamSpec> schema = m_service->algorithmParams(a);
+        if (schema.isEmpty())
+            continue;
+
+        auto* panel = new vos::ParamPanel(a, schema, host);
+        panel->setVisible(false);
+        connect(cb, &QCheckBox::toggled, panel, &QWidget::setVisible);
+        connect(panel, &vos::ParamPanel::changed, this, &DashboardPage::onAlgorithmParamsChanged);
+        m_algoPanels.insert(a, panel);
+        host->layout()->addWidget(panel);
     }
+}
+
+// A knob moved. On a live session push it straight through; otherwise it is
+// picked up by the next deploy, which carries the whole map.
+void DashboardPage::onAlgorithmParamsChanged(const QString& algo, const QVariantMap& values)
+{
+    if (m_sessionId >= 0)
+        m_service->setAlgorithmParams(m_sessionId, algo, values);
+}
+
+// Values for every algorithm currently ticked — an unticked stage is not in the
+// chain, so sending its tuning would be noise.
+AlgorithmSettings DashboardPage::algoParams() const
+{
+    AlgorithmSettings out;
+    for (QCheckBox* cb : m_algoBoxes) {
+        if (!cb->isChecked())
+            continue;
+        const QString algo  = cb->text().toLower();
+        auto*         panel = m_algoPanels.value(algo, nullptr);
+        if (panel)
+            out.insert(algo, panel->values());
+    }
+    return out;
 }
 
 void DashboardPage::onModels(const QVector<DetectorModel>& models)
@@ -440,6 +480,7 @@ void DashboardPage::onStart()
     spec.deviceIndex = m_deviceBox->currentData().toInt();
     spec.capIndex    = m_capsBox->currentData().isValid() ? m_capsBox->currentData().toInt() : 0;
     spec.algosCsv    = algosCsv();
+    spec.algoParams  = algoParams();
     spec.name        = QStringLiteral("dashboard");
     if (m_modelBox->isEnabled()) {
         spec.detectorModel = m_modelBox->currentData().toString();

--- a/concept_A/GuiMediaFusion/pages/DashboardPage.h
+++ b/concept_A/GuiMediaFusion/pages/DashboardPage.h
@@ -22,7 +22,8 @@ class QSlider;
 class QVBoxLayout;
 class VideoTile;
 
-namespace vos { class MiniBars; class KeyValueRow; class StatTile; class Badge; class ToggleSwitch; }
+namespace vos { class MiniBars; class KeyValueRow; class StatTile; class Badge; class ToggleSwitch;
+                class ParamPanel; }
 
 class DashboardPage : public QWidget
 {
@@ -45,6 +46,7 @@ private slots:
     void onModels(const QVector<DetectorModel>& models);
     void onInferenceStats(int sessionId, const InferenceSnapshot& snapshot);
     void onDetectorSettingChanged();     // model / confidence moved by the operator
+    void onAlgorithmParamsChanged(const QString& algo, const QVariantMap& values);
     void onStart();
     void onStop();
     void onSessionStarted(int sessionId, const QString& socket, const QString& desc);
@@ -55,7 +57,8 @@ private slots:
 private:
     QWidget* buildCenterColumn();
     QWidget* buildConfigPanel();
-    QString  algosCsv() const;
+    QString           algosCsv() const;
+    AlgorithmSettings algoParams() const;
     // Enables/checks the GPU_ACCELERATION toggle from detected backends + the
     // current selection (disabled + off when no GPU is present).
     void     refreshAccelToggle();
@@ -70,6 +73,8 @@ private:
     QComboBox*   m_deviceBox = nullptr;
     QComboBox*   m_capsBox   = nullptr;
     QList<QCheckBox*> m_algoBoxes;
+    // algorithm name → its generated controls; only for stages with knobs.
+    QHash<QString, vos::ParamPanel*> m_algoPanels;
     QPushButton* m_startBtn  = nullptr;
     QPushButton* m_stopBtn   = nullptr;
     QLabel*      m_hwLabel   = nullptr;

--- a/concept_A/GuiMediaFusion/pages/PipelinePage.cpp
+++ b/concept_A/GuiMediaFusion/pages/PipelinePage.cpp
@@ -353,8 +353,10 @@ void PipelinePage::onAlgorithms(const QStringList& algos)
         delete item;
     }
     m_algoBoxes.clear();
+    m_algoPanels.clear();
     for (const QString& a : algos) {
         auto* cb = new QCheckBox(a.toUpper(), host);
+        cb->setToolTip(m_service->algorithmSummary(a));
         connect(cb, &QCheckBox::toggled, this, [this] {
             QStringList active;
             for (QCheckBox* b : m_algoBoxes)
@@ -364,6 +366,22 @@ void PipelinePage::onAlgorithms(const QStringList& algos)
         });
         m_algoBoxes.append(cb);
         host->layout()->addWidget(cb);
+
+        // Controls for this stage's knobs, revealed with the stage itself.
+        const QVector<AlgorithmParamSpec> schema = m_service->algorithmParams(a);
+        if (schema.isEmpty())
+            continue;
+
+        auto* panel = new vos::ParamPanel(a, schema, host);
+        panel->setVisible(false);
+        connect(cb, &QCheckBox::toggled, panel, &QWidget::setVisible);
+        connect(panel, &vos::ParamPanel::changed, this,
+                [this](const QString& algo, const QVariantMap& values) {
+            if (m_sessionId >= 0)
+                m_service->setAlgorithmParams(m_sessionId, algo, values);
+        });
+        m_algoPanels.insert(a, panel);
+        host->layout()->addWidget(panel);
     }
     m_canvas->setNodeTitle(1, QStringLiteral("PASSTHROUGH"));
 }
@@ -376,8 +394,14 @@ void PipelinePage::onDeploy()
     spec.deviceIndex = m_deviceBox->currentData().toInt();
     spec.capIndex    = m_capsBox->currentData().isValid() ? m_capsBox->currentData().toInt() : 0;
     QStringList active;
-    for (QCheckBox* b : m_algoBoxes)
-        if (b->isChecked()) active << b->text().toLower();
+    for (QCheckBox* b : m_algoBoxes) {
+        if (!b->isChecked())
+            continue;
+        const QString algo = b->text().toLower();
+        active << algo;
+        if (auto* panel = m_algoPanels.value(algo, nullptr))
+            spec.algoParams.insert(algo, panel->values());
+    }
     spec.algosCsv   = active.join(',');
     spec.screenSink = m_sinkScreen->isChecked();
     spec.name       = QStringLiteral("pipeline-editor");

--- a/concept_A/GuiMediaFusion/pages/PipelinePage.h
+++ b/concept_A/GuiMediaFusion/pages/PipelinePage.h
@@ -20,6 +20,8 @@ class QStackedWidget;
 
 class NodeCanvas;
 
+namespace vos { class ParamPanel; }
+
 class PipelinePage : public QWidget
 {
     Q_OBJECT
@@ -49,6 +51,8 @@ private:
     QComboBox*      m_capsBox    = nullptr;
     QComboBox*      m_modelBox   = nullptr;
     QList<QCheckBox*> m_algoBoxes;
+    // algorithm name → its generated controls; only for stages with knobs.
+    QHash<QString, vos::ParamPanel*> m_algoPanels;
     QRadioButton*   m_sinkApp    = nullptr;
     QRadioButton*   m_sinkScreen = nullptr;
     QPushButton*    m_deployBtn  = nullptr;

--- a/concept_A/GuiMediaFusion/widgets/Components.cpp
+++ b/concept_A/GuiMediaFusion/widgets/Components.cpp
@@ -1,10 +1,13 @@
 #include "Components.h"
 #include "../theme/Theme.h"
 
+#include <QCheckBox>
+#include <QComboBox>
 #include <QHBoxLayout>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
+#include <QSlider>
 #include <QVBoxLayout>
 
 namespace vos {
@@ -330,6 +333,100 @@ KeyValueRow::KeyValueRow(const QString& key, const QString& value,
 void KeyValueRow::setValue(const QString& v) { m_value->setText(v); }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+namespace {
+
+// Decimals worth showing for a knob, taken from its step: 1 -> 0, 0.05 -> 2.
+int decimalsFor(const AlgorithmParamSpec& p)
+{
+    if (p.type != QLatin1String("float"))
+        return 0;
+    int    decimals = 0;
+    double step     = p.step > 0.0 ? p.step : 0.01;
+    while (step < 1.0 && decimals < 4) {
+        step *= 10.0;
+        ++decimals;
+    }
+    return decimals;
+}
+
+} // namespace
+
+ParamPanel::ParamPanel(const QString& algo, const QVector<AlgorithmParamSpec>& schema,
+                       QWidget* parent)
+    : QWidget(parent), m_algo(algo)
+{
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(12, 2, 0, 6);      // indented under its checkbox
+    outer->setSpacing(4);
+
+    for (const AlgorithmParamSpec& p : schema) {
+        m_values.insert(p.key, p.def);
+
+        if (p.type == QLatin1String("bool")) {
+            auto* box = new QCheckBox(p.label, this);
+            box->setChecked(p.def != 0.0);
+            connect(box, &QCheckBox::toggled, this,
+                    [this, key = p.key](bool on) { commit(key, on ? 1.0 : 0.0); });
+            outer->addWidget(box);
+            continue;
+        }
+
+        if (p.type == QLatin1String("enum")) {
+            outer->addWidget(capsLabel(p.label, 8, this));
+            auto* combo = new QComboBox(this);
+            for (const QString& choice : p.choices)
+                combo->addItem(choice.toUpper());
+            combo->setCurrentIndex(static_cast<int>(p.def));
+            connect(combo, &QComboBox::currentIndexChanged, this,
+                    [this, key = p.key](int index) { commit(key, index); });
+            outer->addWidget(combo);
+            continue;
+        }
+
+        // Int and float both ride an integer slider; a float is stepped into
+        // whole units so the widget stays exact and the value is scaled back.
+        const int    decimals = decimalsFor(p);
+        const double step     = p.step > 0.0 ? p.step : 1.0;
+        const int    steps    = qMax(1, qRound((p.max - p.min) / step));
+
+        auto* row = new QHBoxLayout;
+        row->addWidget(capsLabel(p.label, 8, this));
+        row->addStretch(1);
+        auto* readout = dataLabel(QString::number(p.def, 'f', decimals), 10, this);
+        row->addWidget(readout);
+        outer->addLayout(row);
+
+        auto* slider = new QSlider(Qt::Horizontal, this);
+        slider->setRange(0, steps);
+        slider->setValue(qRound((p.def - p.min) / step));
+
+        const auto valueAt = [min = p.min, step](int tick) { return min + tick * step; };
+
+        // Track while dragging so the number follows the thumb...
+        connect(slider, &QSlider::valueChanged, this, [readout, valueAt, decimals](int tick) {
+            readout->setText(QString::number(valueAt(tick), 'f', decimals));
+        });
+        // ...but only commit on release: dragging would otherwise fire one
+        // control command per pixel, the same rule the confidence slider uses.
+        connect(slider, &QSlider::sliderReleased, this, [this, slider, valueAt, key = p.key] {
+            commit(key, valueAt(slider->value()));
+        });
+        // Keyboard and click-on-groove moves never emit sliderReleased.
+        connect(slider, &QSlider::actionTriggered, this,
+                [this, slider, valueAt, key = p.key](int action) {
+            if (action != QAbstractSlider::SliderMove)
+                commit(key, valueAt(slider->sliderPosition()));
+        });
+        outer->addWidget(slider);
+    }
+}
+
+void ParamPanel::commit(const QString& key, double value)
+{
+    m_values.insert(key, value);
+    emit changed(m_algo, m_values);
+}
 
 QLabel* capsLabel(const QString& text, int pt, QWidget* parent, qreal tracking)
 {

--- a/concept_A/GuiMediaFusion/widgets/Components.h
+++ b/concept_A/GuiMediaFusion/widgets/Components.h
@@ -4,8 +4,11 @@
 // cannot express lives here (LEDs, toggle switch, badges, mini charts); each
 // widget follows the Stitch design's geometry.
 
+#include "../core/InferenceTypes.h"
+
 #include <QFrame>
 #include <QLabel>
+#include <QVariantMap>
 #include <QVector>
 #include <QWidget>
 
@@ -140,6 +143,35 @@ public:
     void setValue(const QString& v);
 private:
     QLabel* m_value;
+};
+
+// ── ParamPanel ── controls generated from an algorithm's parameter schema ────
+//
+// The console does not know what any given knob means: it renders a slider, a
+// checkbox or a combo from the descriptor the daemon sent, and reports values
+// back under the algorithm's name. An algorithm added to the engine therefore
+// arrives here with working controls and no GUI change.
+//
+// Emits changed() only on a committed edit (slider release, not drag), so a
+// live session gets one control command per adjustment rather than per pixel.
+class ParamPanel : public QWidget
+{
+    Q_OBJECT
+public:
+    ParamPanel(const QString& algo, const QVector<AlgorithmParamSpec>& schema,
+               QWidget* parent = nullptr);
+
+    QString     algorithm() const { return m_algo; }
+    QVariantMap values() const    { return m_values; }
+
+signals:
+    void changed(const QString& algo, const QVariantMap& values);
+
+private:
+    void commit(const QString& key, double value);
+
+    QString     m_algo;
+    QVariantMap m_values;
 };
 
 // Mono ALL_CAPS label helpers (the design's label-caps / data-mono styles).

--- a/concept_A/MediaFusionGCV/Algorithm.h
+++ b/concept_A/MediaFusionGCV/Algorithm.h
@@ -2,6 +2,7 @@
 
 #include "InferenceStats.h"
 #include "AccelBackend.h"
+#include "AlgorithmParam.h"
 
 #include <opencv2/core.hpp>
 
@@ -28,6 +29,15 @@ public:
     // changes. Plain CPU OpenCV ops ignore it; an inference stage uses it to pick
     // between its cv::dnn (CPU) and ncnn-Vulkan / CUDA engines.
     virtual void        setAccel(AccelBackend) {}
+
+    // Optional: apply tuning values, keyed by AlgorithmParam::key. Called before
+    // the stage sees a frame and again whenever the operator changes a control,
+    // so it may run while streaming — a stage that keeps derived state must
+    // rebuild it here rather than in apply(). Only the keys the caller changed
+    // are present; anything absent keeps its current value. Values arrive
+    // already clamped to the schema. A stage that declares no parameters (see
+    // the registry in Algorithms.h) never gets this call.
+    virtual void        setParams(const AlgorithmParams&) {}
 
     // Optional: an inference stage reports what it last produced here so the
     // control protocol can serve DETECTION_SUMMARY / latency telemetry without

--- a/concept_A/MediaFusionGCV/AlgorithmParam.cpp
+++ b/concept_A/MediaFusionGCV/AlgorithmParam.cpp
@@ -1,0 +1,23 @@
+#include "AlgorithmParam.h"
+
+#include <algorithm>
+#include <cmath>
+
+double AlgorithmParam::clamp(double v) const
+{
+    if (std::isnan(v))
+        return def;
+
+    double out = std::min(std::max(v, min), max);
+    if (type != Type::Float)
+        out = std::round(out);
+    return out;
+}
+
+AlgorithmParams defaultParams(const std::vector<AlgorithmParam>& schema)
+{
+    AlgorithmParams out;
+    for (const auto& p : schema)
+        out[p.key] = p.def;
+    return out;
+}

--- a/concept_A/MediaFusionGCV/AlgorithmParam.h
+++ b/concept_A/MediaFusionGCV/AlgorithmParam.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+// A tunable knob on an Algorithm, described well enough that a client can build
+// a control for it without knowing which algorithm it belongs to.
+//
+// Every value is a double — a bool is 0/1 and an enum is an index into
+// `choices`. One numeric type keeps the wire format a single shape
+// (`key=value`), and it is what a slider produces anyway. The `type` field is
+// what tells a GUI to render a checkbox or a combo instead of a slider.
+//
+// The schema is static per algorithm: it is served by a free function in the
+// registry, not a virtual, so listing the knobs never has to construct an
+// algorithm (constructing a detector starts a worker thread).
+struct AlgorithmParam
+{
+    enum class Type { Int, Float, Bool, Enum };
+
+    std::string              key;      // wire name, lowercase: "low", "min-area"
+    std::string              label;    // human caption: "LOW THRESHOLD"
+    Type                     type = Type::Float;
+    double                   min  = 0.0;
+    double                   max  = 1.0;
+    double                   step = 0.01;
+    double                   def  = 0.0;
+    std::vector<std::string> choices;  // Enum only, indexed by the value
+
+    // Bring a value into range. Int/Bool/Enum additionally snap to whole
+    // numbers, so a client that sends 0.7 for a bool gets 1, not a third state.
+    double clamp(double v) const;
+};
+
+// Parameter values as they travel: algorithm-local, keyed by AlgorithmParam::key.
+using AlgorithmParams = std::map<std::string, double>;
+
+// Defaults for a schema, for a caller that wants a complete value set.
+AlgorithmParams defaultParams(const std::vector<AlgorithmParam>& schema);

--- a/concept_A/MediaFusionGCV/Algorithms.cpp
+++ b/concept_A/MediaFusionGCV/Algorithms.cpp
@@ -99,9 +99,100 @@ private:
     double m_high = 160.0;
 };
 
+// Motion by temporal difference against a running average of the scene.
+//
+// The cheapest useful motion stage, and the reference the heavier subtractors
+// are judged against: one grayscale conversion, one absdiff, one threshold and
+// one accumulate per frame, all single-channel. The running average is what
+// makes it more than a naive frame-to-frame diff — a parked object fades into
+// the background over a few seconds instead of flickering forever, and slow
+// lighting drift is absorbed rather than reported as motion.
+//
+// This is the first stage that keeps state across frames. The state is per
+// instance and FrameProcessor gives every chain its own objects, so two cameras
+// never share a background model.
+class FrameDiffAlgorithm : public Algorithm
+{
+public:
+    const char* name() const override { return "framediff"; }
+
+    void setParams(const AlgorithmParams& p) override
+    {
+        readParam(p, "sensitivity", m_sensitivity);
+        readParam(p, "decay", m_decay);
+        readParam(p, "mode", m_mode);
+    }
+
+    void apply(cv::Mat& frame) override
+    {
+        cv::Mat gray;
+        cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
+
+        // First frame, or a geometry change: seed the model and report nothing.
+        // There is no "previous" to difference against, and claiming the whole
+        // frame moved would blind the operator for a frame.
+        if (m_background.empty() || m_background.size() != gray.size()) {
+            gray.convertTo(m_background, CV_32FC1);
+            return;
+        }
+
+        cv::Mat reference, diff;
+        m_background.convertTo(reference, CV_8UC1);
+        cv::absdiff(gray, reference, diff);
+
+        // Update before rendering, so the cost is paid whichever mode is on and
+        // the model keeps adapting even while the operator is looking at a mask.
+        cv::accumulateWeighted(gray, m_background, m_decay);
+
+        switch (static_cast<int>(m_mode)) {
+            case 1: {   // mask — what the later motion stages will threshold
+                cv::Mat mask;
+                cv::threshold(diff, mask, pixelThreshold(), 255.0, cv::THRESH_BINARY);
+                cv::cvtColor(mask, frame, cv::COLOR_GRAY2BGR);
+                break;
+            }
+            case 2:     // heat — raw difference magnitude, no threshold at all
+                cv::applyColorMap(diff, frame, cv::COLORMAP_INFERNO);
+                break;
+            default: {  // overlay — tint the moving pixels, keep the scene
+                cv::Mat mask;
+                cv::threshold(diff, mask, pixelThreshold(), 255.0, cv::THRESH_BINARY);
+                // Blend rather than paint: a solid fill hides what moved, which
+                // is the thing the operator is trying to look at.
+                cv::Mat tinted = frame.clone();
+                tinted.setTo(cv::Scalar(0, 0, 255), mask);
+                cv::addWeighted(tinted, 0.45, frame, 0.55, 0.0, frame);
+                break;
+            }
+        }
+    }
+
+private:
+    // Sensitivity reads the operator's way round — higher finds smaller changes
+    // — so it is the inverse of the pixel threshold it drives.
+    double pixelThreshold() const { return 101.0 - m_sensitivity; }
+
+    cv::Mat m_background;               // CV_32FC1 running average
+    double  m_sensitivity = 75.0;
+    double  m_decay       = 0.05;
+    double  m_mode        = 0.0;
+};
+
 std::vector<AlgorithmParam> noParams()
 {
     return {};
+}
+
+std::vector<AlgorithmParam> frameDiffParams()
+{
+    return {
+        { "sensitivity", "SENSITIVITY", AlgorithmParam::Type::Int, 1.0, 100.0, 1.0, 75.0, {} },
+        // How fast the background forgets. 0.05 at 20 fps means a still object
+        // is absorbed in roughly a second; lower holds the scene longer.
+        { "decay", "BACKGROUND DECAY", AlgorithmParam::Type::Float, 0.001, 0.5, 0.001, 0.05, {} },
+        { "mode", "RENDER MODE", AlgorithmParam::Type::Enum, 0.0, 2.0, 1.0, 0.0,
+          { "overlay", "mask", "heat" } },
+    };
 }
 
 std::vector<AlgorithmParam> cannyParams()
@@ -128,6 +219,10 @@ const std::vector<AlgorithmInfo>& algorithmRegistry()
         { "canny", "Canny edge map with tunable hysteresis thresholds",
           &cannyParams,
           [] { return std::unique_ptr<Algorithm>(new CannyEdgesAlgorithm()); } },
+
+        { "framediff", "Motion by difference against a running average of the scene",
+          &frameDiffParams,
+          [] { return std::unique_ptr<Algorithm>(new FrameDiffAlgorithm()); } },
 
         // Starts idle; FrameProcessor hands it the selected model right after.
         // Its model and thresholds travel on the dedicated `model` /

--- a/concept_A/MediaFusionGCV/Algorithms.cpp
+++ b/concept_A/MediaFusionGCV/Algorithms.cpp
@@ -28,6 +28,15 @@ bool wantOpenCL(AccelBackend b)
     return cv::ocl::useOpenCL();
 }
 
+// Read one key out of a partial parameter set, keeping the current value when
+// the caller did not send it.
+void readParam(const AlgorithmParams& in, const char* key, double& out)
+{
+    const auto it = in.find(key);
+    if (it != in.end())
+        out = it->second;
+}
+
 class GrayscaleAlgorithm : public Algorithm
 {
 public:
@@ -61,39 +70,101 @@ public:
 
     void setAccel(AccelBackend b) override { m_gpu = wantOpenCL(b); }
 
+    void setParams(const AlgorithmParams& p) override
+    {
+        readParam(p, "low", m_low);
+        readParam(p, "high", m_high);
+    }
+
     void apply(cv::Mat& frame) override
     {
         if (m_gpu && cv::ocl::useOpenCL()) {
             cv::UMat uframe, ugray, uedges;
             frame.copyTo(uframe);
             cv::cvtColor(uframe, ugray, cv::COLOR_BGR2GRAY);
-            cv::Canny(ugray, uedges, 80.0, 160.0);
+            cv::Canny(ugray, uedges, m_low, m_high);
             cv::cvtColor(uedges, uframe, cv::COLOR_GRAY2BGR);
             uframe.copyTo(frame);
             return;
         }
         cv::Mat gray, edges;
         cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
-        cv::Canny(gray, edges, 80.0, 160.0);
+        cv::Canny(gray, edges, m_low, m_high);
         cv::cvtColor(edges, frame, cv::COLOR_GRAY2BGR);
     }
 
 private:
-    bool m_gpu = false;
+    bool   m_gpu  = false;
+    double m_low  = 80.0;
+    double m_high = 160.0;
 };
+
+std::vector<AlgorithmParam> noParams()
+{
+    return {};
+}
+
+std::vector<AlgorithmParam> cannyParams()
+{
+    // The hysteresis pair. Scene-dependent enough that the old hardcoded 80/160
+    // was only ever right for one room.
+    return {
+        { "low", "LOW THRESHOLD", AlgorithmParam::Type::Int, 0.0, 255.0, 1.0, 80.0, {} },
+        { "high", "HIGH THRESHOLD", AlgorithmParam::Type::Int, 0.0, 255.0, 1.0, 160.0, {} },
+    };
+}
 
 } // namespace
 
+const std::vector<AlgorithmInfo>& algorithmRegistry()
+{
+    // Menu order. Cheap pixel ops first, inference last, which is also the order
+    // they make sense in a chain.
+    static const std::vector<AlgorithmInfo> registry = {
+        { "grayscale", "Desaturate to luma, kept in BGR so it chains anywhere",
+          &noParams,
+          [] { return std::unique_ptr<Algorithm>(new GrayscaleAlgorithm()); } },
+
+        { "canny", "Canny edge map with tunable hysteresis thresholds",
+          &cannyParams,
+          [] { return std::unique_ptr<Algorithm>(new CannyEdgesAlgorithm()); } },
+
+        // Starts idle; FrameProcessor hands it the selected model right after.
+        // Its model and thresholds travel on the dedicated `model` /
+        // `detect-params` verbs rather than here, because a model is a name and
+        // this schema carries numbers.
+        { "detect", "YOLO object detection, inference on its own worker thread",
+          &noParams,
+          [] { return std::unique_ptr<Algorithm>(new DetectorAlgorithm()); } },
+    };
+    return registry;
+}
+
+const AlgorithmInfo* findAlgorithm(const std::string& name)
+{
+    for (const auto& info : algorithmRegistry())
+        if (name == info.name)
+            return &info;
+    return nullptr;
+}
+
 std::unique_ptr<Algorithm> makeAlgorithm(const std::string& name)
 {
-    if (name == "grayscale") return std::make_unique<GrayscaleAlgorithm>();
-    if (name == "canny")     return std::make_unique<CannyEdgesAlgorithm>();
-    // Starts idle; FrameProcessor hands it the selected model right after.
-    if (name == "detect")    return std::make_unique<DetectorAlgorithm>();
-    return nullptr;
+    const AlgorithmInfo* info = findAlgorithm(name);
+    return info ? info->make() : nullptr;
 }
 
 std::vector<std::string> availableAlgorithms()
 {
-    return { "grayscale", "canny", "detect" };
+    std::vector<std::string> names;
+    names.reserve(algorithmRegistry().size());
+    for (const auto& info : algorithmRegistry())
+        names.emplace_back(info.name);
+    return names;
+}
+
+std::vector<AlgorithmParam> algorithmParams(const std::string& name)
+{
+    const AlgorithmInfo* info = findAlgorithm(name);
+    return info ? info->schema() : std::vector<AlgorithmParam>{};
 }

--- a/concept_A/MediaFusionGCV/Algorithms.h
+++ b/concept_A/MediaFusionGCV/Algorithms.h
@@ -1,15 +1,46 @@
 #pragma once
 
 #include "Algorithm.h"
+#include "AlgorithmParam.h"
+
 #include <memory>
 #include <string>
 #include <vector>
 
-// Factory + registry for the built-in algorithms. Add an entry here (and in
-// Algorithms.cpp) when you add a new Algorithm — e.g. an ONNX-based detector.
+// Registry of the built-in algorithms. ONE table (in Algorithms.cpp) is the
+// source of truth: the factory, the name list the GUI populates its selector
+// from, and the parameter schemas all read from it, so adding an algorithm is
+// adding a row plus the class it points at.
+struct AlgorithmInfo
+{
+    // Wire name. Lowercase, no spaces — the console stores it in a widget's
+    // caption and round-trips it through upper/lower case, so a mixed-case name
+    // would not survive the trip back. Hyphens are fine.
+    const char* name;
+
+    // One line, shown as the control's tooltip.
+    const char* summary;
+
+    // Tunable knobs, or {} for a stage with none. A free function rather than a
+    // virtual on purpose: listing the menu must not construct anything, and
+    // constructing a detector starts a worker thread.
+    std::vector<AlgorithmParam> (*schema)();
+
+    std::unique_ptr<Algorithm> (*make)();
+};
+
+// Every algorithm the engine can put in a chain, in menu order.
+const std::vector<AlgorithmInfo>& algorithmRegistry();
+
+// Registry lookup by wire name, or nullptr if there is no such algorithm.
+const AlgorithmInfo* findAlgorithm(const std::string& name);
 
 // Returns a new Algorithm for `name`, or nullptr if unknown.
 std::unique_ptr<Algorithm> makeAlgorithm(const std::string& name);
 
 // Names accepted by makeAlgorithm(), for the GUI to populate its selector.
 std::vector<std::string> availableAlgorithms();
+
+// Parameter schema for `name`; empty for an unknown algorithm or one with no
+// knobs (the two cases are distinguished by findAlgorithm()).
+std::vector<AlgorithmParam> algorithmParams(const std::string& name);

--- a/concept_A/MediaFusionGCV/CMakeLists.txt
+++ b/concept_A/MediaFusionGCV/CMakeLists.txt
@@ -59,6 +59,7 @@ set(LIB_SOURCES
     MediaFusionGCV_API.cpp
     FrameProcessor.cpp
     Algorithms.cpp
+    AlgorithmParam.cpp
     Detector.cpp
     InferenceBackend.cpp
     ModelRegistry.cpp
@@ -111,6 +112,7 @@ add_executable(MediaFusionGCV_Tests
     tests/test_pipeline_lifecycle.cpp
     tests/test_device_enumeration.cpp
     tests/test_inference.cpp
+    tests/test_algorithms.cpp
 )
 
 target_include_directories(MediaFusionGCV_Tests PRIVATE

--- a/concept_A/MediaFusionGCV/FrameProcessor.cpp
+++ b/concept_A/MediaFusionGCV/FrameProcessor.cpp
@@ -3,6 +3,8 @@
 
 #include <opencv2/imgproc.hpp>
 
+#include <algorithm>
+
 FrameProcessor::FrameProcessor()
 {
     gst_video_info_init(&m_info);
@@ -32,24 +34,35 @@ FrameProcessor::~FrameProcessor()
     if (filterElement) { gst_object_unref(filterElement); filterElement = nullptr; }
 }
 
-void FrameProcessor::setAlgorithms(const std::vector<std::string>& names)
+bool FrameProcessor::setAlgorithms(const std::vector<std::string>& names)
 {
-    DetectorConfig cfg = detectorConfig();
-    AccelBackend   accel;
+    // Validate the whole request before building anything: a chain is
+    // all-or-nothing, so a typo cannot half-apply and cannot pass silently.
+    for (const auto& n : names)
+        if (!findAlgorithm(n))
+            return false;
+
+    DetectorConfig                         cfg = detectorConfig();
+    AccelBackend                           accel;
+    std::map<std::string, AlgorithmParams> params;
     {
         std::lock_guard<std::mutex> lk(m_mutex);
-        accel = m_accel;
+        accel  = m_accel;
+        params = m_algoParams;
     }
 
     std::vector<std::unique_ptr<Algorithm>> built;
     built.reserve(names.size());
     for (const auto& n : names) {
         auto a = makeAlgorithm(n);
-        if (!a)
-            continue;
         // Pick the resolved backend before loading so a detector configures the
         // right engine on the spot; plain filters ignore it.
         a->setAccel(accel);
+        // Replay the operator's tuning onto the fresh stage, which would
+        // otherwise come up on its compiled-in defaults.
+        const auto it = params.find(n);
+        if (it != params.end() && !it->second.empty())
+            a->setParams(it->second);
         // A detector joining the chain inherits the model chosen earlier;
         // loading happens here, off the streaming thread.
         if (auto* det = dynamic_cast<DetectorAlgorithm*>(a.get()))
@@ -59,6 +72,53 @@ void FrameProcessor::setAlgorithms(const std::vector<std::string>& names)
 
     std::lock_guard<std::mutex> lk(m_mutex);
     m_algos = std::move(built);
+    return true;
+}
+
+bool FrameProcessor::setAlgorithmParams(const std::string& algo, const AlgorithmParams& values)
+{
+    if (!findAlgorithm(algo))
+        return false;
+
+    // ::-qualified: the member of the same name returns current values, this is
+    // the registry's schema.
+    const std::vector<AlgorithmParam> schema = ::algorithmParams(algo);
+
+    // Clamp against the schema here, so every stage can trust what it receives
+    // and no client has to reimplement the ranges.
+    AlgorithmParams clamped;
+    for (const auto& [key, value] : values) {
+        const auto p = std::find_if(schema.begin(), schema.end(),
+                                    [&key](const AlgorithmParam& s) { return s.key == key; });
+        if (p == schema.end())
+            return false;
+        clamped[key] = p->clamp(value);
+    }
+
+    std::lock_guard<std::mutex> lk(m_mutex);
+    for (const auto& [key, value] : clamped)
+        m_algoParams[algo][key] = value;
+
+    // Push to a matching stage already streaming. The streaming thread waits on
+    // this mutex meanwhile, which is what makes a live tweak safe.
+    for (const auto& a : m_algos)
+        if (algo == a->name())
+            a->setParams(clamped);
+    return true;
+}
+
+AlgorithmParams FrameProcessor::algorithmParams(const std::string& algo) const
+{
+    // Schema defaults with the operator's overrides on top, so a caller always
+    // sees a complete, current value set.
+    AlgorithmParams out = defaultParams(::algorithmParams(algo));
+
+    std::lock_guard<std::mutex> lk(m_mutex);
+    const auto it = m_algoParams.find(algo);
+    if (it != m_algoParams.end())
+        for (const auto& [key, value] : it->second)
+            out[key] = value;
+    return out;
 }
 
 void FrameProcessor::setAccel(AccelBackend backend)

--- a/concept_A/MediaFusionGCV/FrameProcessor.h
+++ b/concept_A/MediaFusionGCV/FrameProcessor.h
@@ -6,6 +6,7 @@
 #include "Algorithm.h"
 #include "Detector.h"
 
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -36,9 +37,19 @@ public:
     GstElement* filterElement = nullptr;   // capsfilter, "fp-bgr"
 
     // Replace the active algorithm chain by name (thread-safe; may be called
-    // while streaming). Unknown names are skipped.
-    void                     setAlgorithms(const std::vector<std::string>& names);
+    // while streaming). Rejects the whole request and leaves the current chain
+    // alone if any name is unknown — a typo used to yield a silently empty
+    // chain that still reported success.
+    bool                     setAlgorithms(const std::vector<std::string>& names);
     std::vector<std::string> activeAlgorithms() const;
+
+    // Tuning for one stage, keyed by AlgorithmParam::key. Like the detector
+    // config below these live here rather than in the stage, because
+    // setAlgorithms() rebuilds the chain from names and the operator's settings
+    // have to survive that. Values are clamped to the algorithm's schema;
+    // false means an unknown algorithm or an unknown key.
+    bool            setAlgorithmParams(const std::string& algo, const AlgorithmParams& values);
+    AlgorithmParams algorithmParams(const std::string& algo) const;
 
     // Resolved acceleration backend for the chain (CPU/Vulkan/CUDA). Stored and
     // pushed to every current and future stage, so a detector added later still
@@ -58,6 +69,11 @@ public:
 private:
     static GstPadProbeReturn onBuffer(GstPad* pad, GstPadProbeInfo* info, gpointer user);
     GstPadProbeReturn        processBuffer(GstPad* pad, GstPadProbeInfo* info);
+
+    // Overrides only, not a full value set: a rebuilt stage starts at its own
+    // defaults and these are replayed on top, so a later change to a schema
+    // default is picked up instead of being pinned by a stale copy.
+    std::map<std::string, AlgorithmParams>  m_algoParams;
 
     std::vector<std::unique_ptr<Algorithm>> m_algos;
     DetectorConfig                          m_detectorConfig;

--- a/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
+++ b/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -203,6 +204,109 @@ const char* mediaLib_availableAlgorithms()
 		csv += n;
 	}
 	return csv.c_str();
+}
+
+// std::to_string always spends six decimals, so an int knob would advertise
+// "max=255.000000". Print the shortest form that round-trips instead.
+static std::string numText(double v)
+{
+	std::ostringstream o;
+	o << v;
+	return o.str();
+}
+
+const char* mediaLib_algorithmParams(const char* algoName)
+{
+	static thread_local std::string listing;
+	listing.clear();
+	if (!algoName)
+		return listing.c_str();
+
+	for (const auto& p : algorithmParams(algoName)) {
+		listing += "key=" + p.key;
+		listing += " type=";
+		switch (p.type) {
+			case AlgorithmParam::Type::Int:   listing += "int";   break;
+			case AlgorithmParam::Type::Bool:  listing += "bool";  break;
+			case AlgorithmParam::Type::Enum:  listing += "enum";  break;
+			case AlgorithmParam::Type::Float: listing += "float"; break;
+		}
+		listing += " min="     + numText(p.min);
+		listing += " max="     + numText(p.max);
+		listing += " step="    + numText(p.step);
+		listing += " default=" + numText(p.def);
+		// Pipe-separated so the field stays one whitespace-delimited token.
+		listing += " choices=";
+		for (size_t i = 0; i < p.choices.size(); ++i) {
+			if (i) listing += '|';
+			listing += p.choices[i];
+		}
+		// Label last: it is the only field that may contain spaces, matching
+		// how `stats` puts a detection's label at the end of its line.
+		listing += " label=" + p.label;
+		listing += "\n";
+	}
+	return listing.c_str();
+}
+
+// "low=90,high=200" -> the map. False on a malformed pair or an unparsable
+// number, so a typo is reported rather than silently dropping a knob.
+static bool parseParamCsv(const char* csv, AlgorithmParams& out)
+{
+	if (!csv)
+		return true;
+
+	std::stringstream ss(csv);
+	std::string item;
+	while (std::getline(ss, item, ',')) {
+		size_t a = item.find_first_not_of(" \t");
+		if (a == std::string::npos)
+			continue;                       // tolerate "a=1,,b=2" and trailing commas
+		size_t b = item.find_last_not_of(" \t");
+		item     = item.substr(a, b - a + 1);
+
+		const size_t eq = item.find('=');
+		if (eq == std::string::npos || eq == 0)
+			return false;
+
+		try {
+			size_t consumed = 0;
+			const double value = std::stod(item.substr(eq + 1), &consumed);
+			if (consumed != item.size() - eq - 1)
+				return false;
+			out[item.substr(0, eq)] = value;
+		} catch (const std::exception&) {
+			return false;
+		}
+	}
+	return true;
+}
+
+errorState mediaLib_setAlgorithmParams(size_t pipelineId, const char* algoName, const char* kvCsv)
+{
+	if (pipelineId >= pipelines.size() || pipelines[pipelineId] == nullptr)
+		return errorState::NULLPTR_ERR;
+	if (!algoName)
+		return errorState::INVALID_ARGS_ERR;
+
+	AlgorithmParams values;
+	if (!parseParamCsv(kvCsv, values))
+		return errorState::INVALID_ARGS_ERR;
+	return pipelines[pipelineId]->setAlgorithmParams(algoName, values);
+}
+
+const char* mediaLib_getAlgorithmParams(size_t pipelineId, const char* algoName)
+{
+	static thread_local std::string listing;
+	listing.clear();
+	if (pipelineId >= pipelines.size() || pipelines[pipelineId] == nullptr || !algoName)
+		return listing.c_str();
+
+	for (const auto& [key, value] : pipelines[pipelineId]->algorithmParams(algoName)) {
+		if (!listing.empty()) listing += ',';
+		listing += key + "=" + numText(value);
+	}
+	return listing.c_str();
 }
 
 errorState mediaLib_setDetectorModel(size_t pipelineId, const char* modelNameOrPath)

--- a/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
+++ b/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
@@ -222,6 +222,14 @@ const char* mediaLib_algorithmParams(const char* algoName)
 	if (!algoName)
 		return listing.c_str();
 
+	// What the stage does, on its own line because it reads as prose. A client
+	// shows it as the control's tooltip; it is also how an algorithm with no
+	// knobs still has something to say for itself.
+	const AlgorithmInfo* info = findAlgorithm(algoName);
+	if (!info)
+		return listing.c_str();
+	listing += std::string("summary=") + info->summary + "\n";
+
 	for (const auto& p : algorithmParams(algoName)) {
 		listing += "key=" + p.key;
 		listing += " type=";

--- a/concept_A/MediaFusionGCV/MediaFusionGCV_API.h
+++ b/concept_A/MediaFusionGCV/MediaFusionGCV_API.h
@@ -76,6 +76,23 @@ extern "C" {
 	MEDIAFUSIONGCV_API errorState  mediaLib_setAlgorithms(size_t, const char* csvNames);
 	MEDIAFUSIONGCV_API const char* mediaLib_availableAlgorithms();
 
+	// Per-algorithm tuning. The schema describes each knob well enough to build
+	// a control for it without knowing the algorithm — one line per parameter:
+	// "key=<k> type=<int|float|bool|enum> min=<f> max=<f> step=<f> default=<f>
+	//  choices=<a|b|c> label=<TEXT>", label last because it may contain spaces.
+	// Empty for an unknown algorithm or one with no knobs.
+	//
+	// Values are "k=v" comma-separated ("low=90,high=200"); a bool is 0/1 and an
+	// enum is an index into choices. Out-of-range values are clamped, an unknown
+	// key is INVALID_ARGS_ERR. Settings are remembered per pipeline and survive
+	// changes to the algorithm chain, so they can be sent before the stage is
+	// selected. The getter returns current values, "k=v" comma-separated.
+	// Pointers valid until the next call.
+	MEDIAFUSIONGCV_API const char* mediaLib_algorithmParams(const char* algoName);
+	MEDIAFUSIONGCV_API errorState  mediaLib_setAlgorithmParams(size_t, const char* algoName,
+	                                                           const char* kvCsv);
+	MEDIAFUSIONGCV_API const char* mediaLib_getAlgorithmParams(size_t, const char* algoName);
+
 	// Inference stage — configures the "detect" algorithm. The model is loaded
 	// on the spot, so LOAD_MODEL_ERR here means a missing or unreadable graph;
 	// an empty name unloads it. Detector settings are remembered per pipeline

--- a/concept_A/MediaFusionGCV/PipelineManager.cpp
+++ b/concept_A/MediaFusionGCV/PipelineManager.cpp
@@ -3,6 +3,7 @@
 #include "GStreamerSinkScreen.h"
 #include "GStreamerSinkApplication.h"
 #include "FrameProcessor.h"
+#include "Algorithms.h"
 #include "ModelRegistry.h"
 #include "AcceleratorRegistry.h"
 
@@ -207,8 +208,30 @@ errorState PipelineManager::setAlgorithms(const std::vector<std::string>& names)
     ensureProcessor();                      // selecting algorithms enables the stage
     if (!processor->valid())
         return errorState::OBJECT_CREATION_ERR;
-    processor->setAlgorithms(names);
+    if (!processor->setAlgorithms(names))
+        return errorState::INVALID_ARGS_ERR;
     return errorState::NO_ERR;
+}
+
+errorState PipelineManager::setAlgorithmParams(const std::string&     algo,
+                                               const AlgorithmParams& values)
+{
+    // Same reasoning as setDetectorModel: tuning is accepted before the stage
+    // is in the chain and replayed when it joins, so the console can set a
+    // control and deploy in either order.
+    ensureProcessor();
+    if (!processor->valid())
+        return errorState::OBJECT_CREATION_ERR;
+    if (!processor->setAlgorithmParams(algo, values))
+        return errorState::INVALID_ARGS_ERR;
+    return errorState::NO_ERR;
+}
+
+AlgorithmParams PipelineManager::algorithmParams(const std::string& algo) const
+{
+    if (!processor || !processor->valid())
+        return defaultParams(::algorithmParams(algo));
+    return processor->algorithmParams(algo);
 }
 
 errorState PipelineManager::setDetectorModel(const std::string& modelNameOrPath)

--- a/concept_A/MediaFusionGCV/PipelineManager.h
+++ b/concept_A/MediaFusionGCV/PipelineManager.h
@@ -11,6 +11,7 @@
 #include "errorState.h"
 #include "InferenceStats.h"
 #include "AccelBackend.h"
+#include "AlgorithmParam.h"
 
 #include "GStreamerSource.h"
 #include "GStreamerSink.h"
@@ -43,6 +44,13 @@ public:
     // implies enabling. Algorithm names come from availableAlgorithms().
     void       setProcessingEnabled(bool enabled);
     errorState setAlgorithms(const std::vector<std::string>& names);
+
+    // Tuning for one algorithm, keyed by AlgorithmParam::key (schemas come from
+    // algorithmParams()). Accepted whether or not the stage is currently in the
+    // chain, and replayed when it joins. INVALID_ARGS_ERR for an unknown
+    // algorithm or key; values outside a knob's range are clamped, not refused.
+    errorState      setAlgorithmParams(const std::string& algo, const AlgorithmParams& values);
+    AlgorithmParams algorithmParams(const std::string& algo) const;
 
     // Inference stage — the "detect" algorithm. The model is loaded here and
     // now (not lazily at start) so a bad name or an unreadable graph is

--- a/concept_A/MediaFusionGCV/errorState.h
+++ b/concept_A/MediaFusionGCV/errorState.h
@@ -25,6 +25,7 @@ extern "C" {
 		START_STREAMING_FAILED,
 		STOP_STREAMING_FAILED,
 		LOAD_MODEL_ERR,
+		INVALID_ARGS_ERR,
 		NO_ERR
 	};
 #ifdef __cplusplus

--- a/concept_A/MediaFusionGCV/main.cpp
+++ b/concept_A/MediaFusionGCV/main.cpp
@@ -47,6 +47,7 @@ static std::string errStr(errorState e)
         case errorState::START_STREAMING_FAILED:    return "START_STREAMING_FAILED";
         case errorState::STOP_STREAMING_FAILED:     return "STOP_STREAMING_FAILED";
         case errorState::LOAD_MODEL_ERR:            return "LOAD_MODEL_ERR";
+        case errorState::INVALID_ARGS_ERR:          return "INVALID_ARGS";
         case errorState::SET_SOURCE_ELEMENT_ERR:    return "SET_SOURCE_ELEMENT_ERR";
         case errorState::SET_SINK_ELEMENT_ERR:      return "SET_SINK_ELEMENT_ERR";
         case errorState::SET_SOURCE_CAPS_ERR:       return "SET_SOURCE_CAPS_ERR";
@@ -115,6 +116,9 @@ static std::string helpText()
         << "  set-device <id> <dev> <cap>      Select Device [dev] Cap [cap] from 'devices' output\n"
         << "  algos <id> <csv>                 Set OpenCV algorithm chain (empty csv disables)\n"
         << "  algos-list                       List available algorithm names\n"
+        << "  algo-params <algo>               Describe an algorithm's tunable parameters\n"
+        << "  algo-set <id> <algo> <k=v,k=v>   Tune an algorithm (e.g. algo-set 0 canny low=90)\n"
+        << "  algo-get <id> <algo>             Show an algorithm's current parameter values\n"
         << "  accelerators                     List detected accel backends (cpu/vulkan/cuda)\n"
         << "  models                           List installed detector models\n"
         << "  model <id> [name]                Load a detector model (no name unloads it)\n"
@@ -231,6 +235,46 @@ static std::string handleCommand(const std::string& line)
     }
     else if (cmd == "algos-list") {
         out << "OK " << mediaLib_availableAlgorithms() << "\n";
+    }
+    else if (cmd == "algo-params") {
+        // Schema only — no pipeline needed, so a client can build its controls
+        // before anything is created.
+        std::string algo;
+        if (!(iss >> algo))
+            out << "ERR INVALID_ARGS algo-params <algo>\n";
+        else {
+            const std::string schema = mediaLib_algorithmParams(algo.c_str());
+            const size_t      lines  = std::count(schema.begin(), schema.end(), '\n');
+            out << "OK " << lines << " param(s)\n" << schema;
+        }
+    }
+    else if (cmd == "algo-set") {
+        size_t      id = 0;
+        std::string algo;
+        if (!(iss >> id >> algo))
+            out << "ERR INVALID_ARGS algo-set <id> <algo> <k=v,k=v>\n";
+        else {
+            std::string kv;
+            std::getline(iss, kv);                        // rest of line
+            size_t a = kv.find_first_not_of(" \t");
+            kv = (a == std::string::npos) ? "" : kv.substr(a);
+            errorState err = mediaLib_setAlgorithmParams(id, algo.c_str(), kv.c_str());
+            if (err == errorState::NO_ERR)
+                out << "OK\n";
+            else {
+                out << "ERR " << errStr(err) << "\n";
+                if (err == errorState::INVALID_ARGS_ERR)
+                    out << "  hint: run 'algo-params " << algo << "' for the keys and ranges\n";
+            }
+        }
+    }
+    else if (cmd == "algo-get") {
+        size_t      id = 0;
+        std::string algo;
+        if (!(iss >> id >> algo))
+            out << "ERR INVALID_ARGS algo-get <id> <algo>\n";
+        else
+            out << "OK " << mediaLib_getAlgorithmParams(id, algo.c_str()) << "\n";
     }
     else if (cmd == "accelerators") {
         // One line per backend the host can run; the GUI shows only available=1.

--- a/concept_A/MediaFusionGCV/main.cpp
+++ b/concept_A/MediaFusionGCV/main.cpp
@@ -244,8 +244,15 @@ static std::string handleCommand(const std::string& line)
             out << "ERR INVALID_ARGS algo-params <algo>\n";
         else {
             const std::string schema = mediaLib_algorithmParams(algo.c_str());
-            const size_t      lines  = std::count(schema.begin(), schema.end(), '\n');
-            out << "OK " << lines << " param(s)\n" << schema;
+            // Count the knobs, not the lines: the reply also carries a summary=
+            // line, and a stage with no parameters still has one.
+            size_t             params = 0;
+            std::istringstream lines(schema);
+            std::string        line;
+            while (std::getline(lines, line))
+                if (line.rfind("key=", 0) == 0)
+                    ++params;
+            out << "OK " << params << " param(s)\n" << schema;
         }
     }
     else if (cmd == "algo-set") {

--- a/concept_A/MediaFusionGCV/tests/test_algorithms.cpp
+++ b/concept_A/MediaFusionGCV/tests/test_algorithms.cpp
@@ -1,0 +1,235 @@
+// Standard and OpenCV headers first, deliberately: gstcheck.h defines a `fail`
+// macro that collides with std::basic_ios::fail() once <iostream> is pulled in
+// behind it (OpenCV does exactly that).
+#include <opencv2/imgproc.hpp>
+
+#include <string>
+#include <vector>
+
+#include <gst/check/gstcheck.h>
+#include "MediaFusionGCV_API.h"
+#include "Algorithms.h"
+
+// Coverage for the algorithm registry and the parameter seam. The first two
+// cases walk the whole registry, so an algorithm added later is checked against
+// the Algorithm contract without anyone remembering to write a test for it.
+
+// Every declared schema has to be usable by a client that only knows the
+// descriptor: a range it can build a control from, and a default inside it.
+GST_START_TEST(test_every_schema_is_well_formed)
+{
+    for (const auto& info : algorithmRegistry()) {
+        fail_unless(info.name != nullptr && *info.name != '\0', "an algorithm has no name");
+        fail_unless(info.summary != nullptr && *info.summary != '\0',
+            "algorithm '%s' has no summary", info.name);
+
+        // The console round-trips the name through upper case and back, so a
+        // name that is not already lowercase would not survive the trip.
+        const std::string name = info.name;
+        for (char c : name)
+            fail_unless(!(c >= 'A' && c <= 'Z'),
+                "algorithm name '%s' must be lowercase to survive the GUI round trip",
+                info.name);
+        fail_unless(name.find(' ') == std::string::npos,
+            "algorithm name '%s' must not contain spaces", info.name);
+
+        for (const auto& p : info.schema()) {
+            fail_unless(!p.key.empty(), "%s: a parameter has no key", info.name);
+            fail_unless(!p.label.empty(), "%s: parameter '%s' has no label",
+                info.name, p.key.c_str());
+            fail_unless(p.min < p.max, "%s: parameter '%s' has an empty range [%f, %f]",
+                info.name, p.key.c_str(), p.min, p.max);
+            fail_unless(p.def >= p.min && p.def <= p.max,
+                "%s: parameter '%s' default %f is outside [%f, %f]",
+                info.name, p.key.c_str(), p.def, p.min, p.max);
+            fail_unless(p.step > 0.0, "%s: parameter '%s' has a non-positive step",
+                info.name, p.key.c_str());
+
+            if (p.type == AlgorithmParam::Type::Enum)
+                fail_unless(!p.choices.empty(),
+                    "%s: enum parameter '%s' offers no choices", info.name, p.key.c_str());
+            else
+                fail_unless(p.choices.empty(),
+                    "%s: non-enum parameter '%s' must not carry choices",
+                    info.name, p.key.c_str());
+        }
+    }
+}
+GST_END_TEST
+
+// The contract in Algorithm.h: apply() may not change the frame's size or type,
+// because the pipeline caps are fixed for the buffer's lifetime. Breaking this
+// takes the stream down, so it is worth enforcing mechanically.
+GST_START_TEST(test_every_algorithm_preserves_frame_geometry)
+{
+    for (const auto& info : algorithmRegistry()) {
+        auto algo = info.make();
+        fail_unless(algo != nullptr, "registry entry '%s' produced nothing", info.name);
+        fail_unless(std::string(algo->name()) == info.name,
+            "registry name '%s' does not match the object's name '%s'",
+            info.name, algo->name());
+
+        // Something with structure in it, so a stage that keys off content has
+        // work to do rather than seeing flat colour.
+        cv::Mat frame(120, 160, CV_8UC3, cv::Scalar(30, 60, 90));
+        cv::rectangle(frame, cv::Rect(40, 30, 50, 40), cv::Scalar(220, 220, 220), -1);
+
+        // Defaults first, then the extremes of every knob: a stage must not be
+        // able to crash or resize the frame at either end of its own range.
+        algo->setParams(defaultParams(info.schema()));
+        algo->apply(frame);
+        for (const auto& p : info.schema()) {
+            for (double v : { p.min, p.max }) {
+                algo->setParams({ { p.key, v } });
+                algo->apply(frame);
+            }
+        }
+
+        fail_unless(frame.rows == 120 && frame.cols == 160,
+            "%s resized the frame to %dx%d", info.name, frame.cols, frame.rows);
+        fail_unless(frame.type() == CV_8UC3,
+            "%s changed the frame type to %d", info.name, frame.type());
+        fail_unless(frame.isContinuous() || frame.step >= 160 * 3,
+            "%s replaced the frame with an incompatible buffer", info.name);
+    }
+}
+GST_END_TEST
+
+// The registry is the single source of truth: the name list and the factory
+// must agree, which is exactly what the two hand-synced lists could not
+// guarantee before.
+GST_START_TEST(test_registry_is_the_only_source_of_names)
+{
+    const std::vector<std::string> names = availableAlgorithms();
+    fail_unless(names.size() == algorithmRegistry().size(),
+        "availableAlgorithms() lists %zu names for %zu registry entries",
+        names.size(), algorithmRegistry().size());
+
+    for (const auto& n : names) {
+        fail_unless(findAlgorithm(n) != nullptr, "'%s' is listed but not in the registry",
+            n.c_str());
+        auto algo = makeAlgorithm(n);
+        fail_unless(algo != nullptr, "'%s' is listed but the factory cannot build it",
+            n.c_str());
+    }
+
+    fail_unless(makeAlgorithm("no-such-algorithm") == nullptr,
+        "the factory invented an algorithm that is not registered");
+    fail_unless(findAlgorithm("no-such-algorithm") == nullptr,
+        "lookup found an algorithm that is not registered");
+}
+GST_END_TEST
+
+// A typo used to be skipped silently, leaving an empty chain that still
+// reported success. The whole request is rejected instead.
+GST_START_TEST(test_unknown_algorithm_name_is_rejected)
+{
+    const size_t id = mediaLib_create(SourceType::CAMERA_SOURCE, SinkType::APPLICATION_SINK, "t");
+
+    fail_unless(mediaLib_setAlgorithms(id, "grayscale") == errorState::NO_ERR,
+        "a known algorithm must be accepted");
+    fail_unless(mediaLib_setAlgorithms(id, "grayscale,typo") == errorState::INVALID_ARGS_ERR,
+        "a chain containing an unknown name must be rejected");
+    fail_unless(mediaLib_setAlgorithms(id, "") == errorState::NO_ERR,
+        "an empty chain must stay valid -- it is how processing is disabled");
+
+    mediaLib_delete(id);
+}
+GST_END_TEST
+
+// Canny's thresholds were hardcoded at 80/160; they are the proof that the
+// generic seam reaches a stage with no special-casing anywhere.
+GST_START_TEST(test_canny_thresholds_are_tunable)
+{
+    const std::string schema = mediaLib_algorithmParams("canny");
+    fail_unless(schema.find("key=low") != std::string::npos,
+        "canny must expose a 'low' threshold, got '%s'", schema.c_str());
+    fail_unless(schema.find("key=high") != std::string::npos,
+        "canny must expose a 'high' threshold, got '%s'", schema.c_str());
+
+    const size_t id = mediaLib_create(SourceType::CAMERA_SOURCE, SinkType::APPLICATION_SINK, "t");
+
+    fail_unless(mediaLib_setAlgorithmParams(id, "canny", "low=90,high=200") == errorState::NO_ERR,
+        "valid canny parameters must be accepted");
+
+    // Out of range is clamped, not refused: a slider should never fail.
+    fail_unless(mediaLib_setAlgorithmParams(id, "canny", "low=9999") == errorState::NO_ERR,
+        "an out-of-range value must be clamped rather than rejected");
+    const std::string values = mediaLib_getAlgorithmParams(id, "canny");
+    fail_unless(values.find("low=255") != std::string::npos,
+        "low should have been clamped to 255, got '%s'", values.c_str());
+    fail_unless(values.find("high=200") != std::string::npos,
+        "high should have kept its set value, got '%s'", values.c_str());
+
+    // Unknown keys, unparsable numbers and unknown algorithms are all errors.
+    fail_unless(mediaLib_setAlgorithmParams(id, "canny", "nosuch=1") == errorState::INVALID_ARGS_ERR,
+        "an unknown parameter key must be rejected");
+    fail_unless(mediaLib_setAlgorithmParams(id, "canny", "low=abc") == errorState::INVALID_ARGS_ERR,
+        "an unparsable value must be rejected");
+    fail_unless(mediaLib_setAlgorithmParams(id, "nosuch", "low=1") == errorState::INVALID_ARGS_ERR,
+        "an unknown algorithm must be rejected");
+
+    // A parameterless stage has an empty schema but is still a valid target.
+    fail_unless(std::string(mediaLib_algorithmParams("grayscale")).empty(),
+        "grayscale declares no parameters");
+
+    mediaLib_delete(id);
+}
+GST_END_TEST
+
+// Tuning is remembered per pipeline and replayed onto a stage that joins later,
+// so the console can set a control before deploying, in either order.
+GST_START_TEST(test_params_survive_a_chain_rebuild)
+{
+    const size_t id = mediaLib_create(SourceType::CAMERA_SOURCE, SinkType::APPLICATION_SINK, "t");
+
+    // Set before "canny" is in the chain at all.
+    fail_unless(mediaLib_setAlgorithmParams(id, "canny", "low=42") == errorState::NO_ERR,
+        "parameters must be accepted before the stage is selected");
+    fail_unless(mediaLib_setAlgorithms(id, "canny") == errorState::NO_ERR,
+        "canny must be selectable");
+
+    std::string values = mediaLib_getAlgorithmParams(id, "canny");
+    fail_unless(values.find("low=42") != std::string::npos,
+        "a value set before the stage joined was lost, got '%s'", values.c_str());
+
+    // Rebuilding the chain must not reset it either.
+    fail_unless(mediaLib_setAlgorithms(id, "grayscale,canny") == errorState::NO_ERR,
+        "the chain must be replaceable");
+    values = mediaLib_getAlgorithmParams(id, "canny");
+    fail_unless(values.find("low=42") != std::string::npos,
+        "rebuilding the chain reset the tuning, got '%s'", values.c_str());
+
+    mediaLib_delete(id);
+}
+GST_END_TEST
+
+// Bad ids must be bounced the way every other id-taking entry point does.
+GST_START_TEST(test_param_api_bounds_checks)
+{
+    fail_unless(mediaLib_setAlgorithmParams(9999, "canny", "low=1") == errorState::NULLPTR_ERR,
+        "a bad pipeline id must return NULLPTR_ERR");
+    fail_unless(std::string(mediaLib_getAlgorithmParams(9999, "canny")).empty(),
+        "a bad pipeline id must yield no values");
+    fail_unless(std::string(mediaLib_algorithmParams("no-such-algorithm")).empty(),
+        "an unknown algorithm has no schema");
+    fail_unless(std::string(mediaLib_algorithmParams(nullptr)).empty(),
+        "a null name must not crash");
+}
+GST_END_TEST
+
+Suite* algorithms_suite()
+{
+    Suite*   s  = suite_create("algorithms");
+    TCase*   tc = tcase_create("general");
+
+    suite_add_tcase(s, tc);
+    tcase_add_test(tc, test_every_schema_is_well_formed);
+    tcase_add_test(tc, test_every_algorithm_preserves_frame_geometry);
+    tcase_add_test(tc, test_registry_is_the_only_source_of_names);
+    tcase_add_test(tc, test_unknown_algorithm_name_is_rejected);
+    tcase_add_test(tc, test_canny_thresholds_are_tunable);
+    tcase_add_test(tc, test_params_survive_a_chain_rebuild);
+    tcase_add_test(tc, test_param_api_bounds_checks);
+    return s;
+}

--- a/concept_A/MediaFusionGCV/tests/test_algorithms.cpp
+++ b/concept_A/MediaFusionGCV/tests/test_algorithms.cpp
@@ -218,6 +218,55 @@ GST_START_TEST(test_param_api_bounds_checks)
 }
 GST_END_TEST
 
+// framediff is the first stage that carries state between frames: a still scene
+// must read as still, and something that moves must light up where it moved.
+GST_START_TEST(test_framediff_reports_motion_only_where_it_happened)
+{
+    auto motion = makeAlgorithm("framediff");
+    fail_unless(motion != nullptr, "framediff must be registered");
+
+    // Mask mode, so the result is exactly "what moved" with nothing blended in.
+    motion->setParams({ { "mode", 1.0 }, { "sensitivity", 75.0 } });
+
+    const cv::Scalar background(30, 60, 90);
+    const cv::Rect   startsAt(20, 20, 30, 30);
+    const cv::Rect   movesTo(100, 60, 30, 30);
+
+    cv::Mat frame(120, 160, CV_8UC3, background);
+    cv::rectangle(frame, startsAt, cv::Scalar(240, 240, 240), -1);
+
+    // First frame only seeds the background model — nothing has moved yet.
+    motion->apply(frame);
+
+    // A still scene: feed the same frame again and expect an empty mask.
+    cv::Mat still(120, 160, CV_8UC3, background);
+    cv::rectangle(still, startsAt, cv::Scalar(240, 240, 240), -1);
+    motion->apply(still);
+    cv::Mat stillGray;
+    cv::cvtColor(still, stillGray, cv::COLOR_BGR2GRAY);
+    fail_unless(cv::countNonZero(stillGray) == 0,
+        "a still scene reported %d moving pixels", cv::countNonZero(stillGray));
+
+    // Now move the block. Both the vacated and the newly covered area differ
+    // from the model, so both should register.
+    cv::Mat moved(120, 160, CV_8UC3, background);
+    cv::rectangle(moved, movesTo, cv::Scalar(240, 240, 240), -1);
+    motion->apply(moved);
+
+    cv::Mat movedGray;
+    cv::cvtColor(moved, movedGray, cv::COLOR_BGR2GRAY);
+    fail_unless(cv::countNonZero(movedGray(movesTo)) > 0,
+        "no motion reported where the block moved to");
+    fail_unless(cv::countNonZero(movedGray(startsAt)) > 0,
+        "no motion reported where the block moved from");
+
+    // ... and nowhere else: a corner the block never touched must stay clear.
+    const cv::Rect untouched(130, 95, 25, 20);
+    fail_unless(cv::countNonZero(movedGray(untouched)) == 0,
+        "motion reported in a region nothing moved through");
+}
+GST_END_TEST
+
 Suite* algorithms_suite()
 {
     Suite*   s  = suite_create("algorithms");
@@ -231,5 +280,6 @@ Suite* algorithms_suite()
     tcase_add_test(tc, test_canny_thresholds_are_tunable);
     tcase_add_test(tc, test_params_survive_a_chain_rebuild);
     tcase_add_test(tc, test_param_api_bounds_checks);
+    tcase_add_test(tc, test_framediff_reports_motion_only_where_it_happened);
     return s;
 }

--- a/concept_A/MediaFusionGCV/tests/test_algorithms.cpp
+++ b/concept_A/MediaFusionGCV/tests/test_algorithms.cpp
@@ -169,9 +169,13 @@ GST_START_TEST(test_canny_thresholds_are_tunable)
     fail_unless(mediaLib_setAlgorithmParams(id, "nosuch", "low=1") == errorState::INVALID_ARGS_ERR,
         "an unknown algorithm must be rejected");
 
-    // A parameterless stage has an empty schema but is still a valid target.
-    fail_unless(std::string(mediaLib_algorithmParams("grayscale")).empty(),
-        "grayscale declares no parameters");
+    // A parameterless stage still describes itself — it reports a summary and no
+    // knobs, which is not the same as an unknown algorithm reporting nothing.
+    const std::string grayscale = mediaLib_algorithmParams("grayscale");
+    fail_unless(grayscale.find("key=") == std::string::npos,
+        "grayscale declares no parameters, got '%s'", grayscale.c_str());
+    fail_unless(grayscale.find("summary=") != std::string::npos,
+        "every registered algorithm describes itself, got '%s'", grayscale.c_str());
 
     mediaLib_delete(id);
 }

--- a/concept_A/MediaFusionGCV/tests/test_main.cpp
+++ b/concept_A/MediaFusionGCV/tests/test_main.cpp
@@ -4,6 +4,7 @@ extern Suite* api_null_safety_suite();
 extern Suite* pipeline_lifecycle_suite();
 extern Suite* device_enumeration_suite();
 extern Suite* inference_suite();
+extern Suite* algorithms_suite();
 
 int main(int argc, char** argv)
 {
@@ -13,6 +14,7 @@ int main(int argc, char** argv)
     srunner_add_suite(sr, pipeline_lifecycle_suite());
     srunner_add_suite(sr, device_enumeration_suite());
     srunner_add_suite(sr, inference_suite());
+    srunner_add_suite(sr, algorithms_suite());
 
     srunner_run_all(sr, CK_NORMAL);
     int failed = srunner_ntests_failed(sr);

--- a/docs/GUI_DESIGN.md
+++ b/docs/GUI_DESIGN.md
@@ -87,7 +87,8 @@ Old `GuiMediaFusion{,Model,Controller}`, `PreLaunchSettings.ui`, `guiElements.h`
 | START/STOP stream, REBOOT_CORE, TERMINATE_PID | **REAL** | deploy/stop session; daemon restart/shutdown |
 | Device list & caps selection (Device Manager) | **REAL** | `devices` → DeviceParser; CONNECT = `set-device` |
 | Protocol filter chips USB / RTSP / GigE / CoaXPress | PARTIAL | USB (V4L2) real; others disabled `PLANNED` |
-| Processing chain (Pipeline node PROCESS) | **REAL** | `algos-list` → grayscale/canny/detect checkboxes → `algos` |
+| Processing chain (Pipeline node PROCESS) | **REAL** | `algos-list` → one checkbox per reported algorithm → `algos` |
+| Per-algorithm parameter controls | **REAL** | `algo-params <algo>` → generated sliders/toggles/combos under each checkbox → `algo-set` (live) or carried in the deploy |
 | Pipeline editor canvas SOURCE→PROCESS→SINK | PARTIAL | fixed linear chain (matches backend); node drag `PLANNED` |
 | DEPLOY PIPELINE | **REAL** | create → set-device → algos → start |
 | Multi-grid 2×2 tiles, per-tile source | **REAL**¹ | one session per tile (¹ limited by #cameras) |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -59,6 +59,26 @@ a single camera — before any question of a second one.
 `detect` stage live. Both are gaps in this baseline; fill them when the hardware
 is on the desk.
 
+### Cost of a processing stage
+
+One camera, MJPEG 1280×720, RelWithDebInfo, CPU accel, measured 2026-08-05 in one
+sitting. `framediff` at its defaults and `canny` are both **free at the rate this
+camera delivers**:
+
+| Chain | fps | dropped |
+|---|---|---|
+| (none) | 15.06 | 0 |
+| `framediff` | 15.06 | 0 |
+| `canny` | 15.07 | 0 |
+
+Read that as a budget statement, not as "these stages are free": the camera was
+delivering 15 fps that afternoon (auto-exposure again — the same mode measured
+20.1 fps for the baseline above, in better light), so each frame had ~66 ms of
+slack and a stage costing a few ms cannot show up. The number that would move
+first is `dropped:`, and it did not. To measure a stage's actual cost, a
+synthetic source is needed — the camera cannot be driven fast enough to expose
+it.
+
 ## Landed
 
 | # | Item | Where |
@@ -94,6 +114,13 @@ S (a sitting), M (a session), L (multi-session or needs a design decision).
 | P21 | Per-pipeline retained caps text dump | low | S | open |
 
 ### Notes
+
+**Watch out when the motion stages land.** `framediff` is single-channel and
+cheap. Its successors are not: MOG2 background subtraction is ~10–15 ms at 1080p
+and dense optical flow is far worse, and the whole chain runs on the streaming
+thread holding `FrameProcessor::m_mutex` (see P15). Run the analysis on a
+downscaled copy and scale the result back up for drawing — a motion mask does not
+need 1080p — rather than paying full resolution for it.
 
 **P6 — skip the convert when nothing processes.** `source->converter`
 (`videoconvert`) is created in the `PipelineManager` constructor and always

--- a/scripts/build-opencv.sh
+++ b/scripts/build-opencv.sh
@@ -30,13 +30,19 @@ if [ ! -d "$WORKDIR/opencv/.git" ]; then
         https://github.com/opencv/opencv.git "$WORKDIR/opencv"
 fi
 
-# Only the modules the detector needs. Trimming the module list (no gapi, no
+# Only the modules the engine needs. Trimming the module list (no gapi, no
 # python/java bindings, no videoio/highgui — GStreamer is the engine's job, not
-# OpenCV's) takes the build from ~40 minutes to under ten.
+# OpenCV's) keeps the build far below the ~40 minutes a full one costs.
+#
+# video     — background subtraction (MOG2/KNN) and optical flow, for the motion
+#             algorithms in the processing chain
+# objdetect — the YuNet face detector the privacy/blur stage uses
+# BUILD_LIST pulls each module's dependencies in on its own, so this also brings
+# calib3d/features2d/flann along.
 cmake -S "$WORKDIR/opencv" -B "$WORKDIR/build" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$PREFIX" \
-    -DBUILD_LIST=core,imgproc,imgcodecs,dnn \
+    -DBUILD_LIST=core,imgproc,imgcodecs,dnn,video,objdetect \
     -DOPENCV_GENERATE_PKGCONFIG=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_TESTS=OFF \


### PR DESCRIPTION
# feat: algorithm registry with self-describing parameters, and the first motion stage

The processing chain offered three algorithms — `grayscale`, `canny`, `detect` —
two of which are one-line pixel ops with constants baked in. This opens up the
chain properly, starting with the motion & surveillance family, and lands the
groundwork that makes each later algorithm cheap to add.

The theme: **an algorithm should describe itself, and everything else should
follow from that.** A new stage is now a class plus one registry row. Its name
reaches the console, its knobs become controls, and its contract is enforced by
tests — with no change to the GUI, the C API or the protocol.

## What changed

| Commit | Change |
|---|---|
| `decaf37` | OpenCV built with `video` + `objdetect` (MOG2, optical flow, YuNet), and a CI cache key that hashes the build script |
| `53802c9` | One registry table replaces the two hand-synced lists; the generic parameter seam and its three verbs |
| `ce22b44` | The `algorithms` test suite |
| `bbce678` | `framediff` — the first motion stage |
| `4b116a8` | The console generates parameter controls from the schema |
| `38dd8aa` | README, GUI design matrix, performance notes |
| `5c8bd84` | `algo-params` counts declared knobs rather than reply lines |

### One registry, not two lists

`makeAlgorithm()`'s if-chain and the `availableAlgorithms()` vector were
maintained by hand with nothing checking that they agreed. Both now derive from a
single `AlgorithmInfo` table carrying the name, a one-line summary, the parameter
schema and the factory.

The schema is a **free function pointer rather than a virtual**, deliberately:
`makeAlgorithm("detect")` spawns a worker thread, and listing a menu must not
start threads.

### Parameters, described by the algorithm itself

```
algo-params canny
  OK 2 param(s)
  summary=Canny edge map with tunable hysteresis thresholds
  key=low  type=int min=0 max=255 step=1 default=80  label=LOW THRESHOLD
  key=high type=int min=0 max=255 step=1 default=160 label=HIGH THRESHOLD

algo-set 0 canny low=90,high=200      # live, or carried in the deploy
algo-get 0 canny
```

Values are `double` throughout — a bool is 0/1, an enum is an index — so the wire
format is one shape and matches what a slider produces. Out-of-range input is
**clamped, not refused**: a control should never fail. An unknown key is an
error, because that is a typo rather than a preference.

Settings live in `FrameProcessor` next to the detector config and are replayed
whenever the chain is rebuilt, so a stage never runs a frame on defaults the
operator has changed, and tuning can be sent before the stage is even selected.

Canny's hardcoded `80.0, 160.0` moved onto this as the proof it works with no
special-casing anywhere. `detect` keeps its own `model` / `detect-params` verbs —
a model is a name, not a number, and those already work.

### Controls the console did not have to be told about

The GUI already discovered algorithm *names* from `algos-list`. It now fetches
each schema too and generates a slider, checkbox or combo per descriptor, shown
under its checkbox and hidden when the stage is off. Commit is on
`sliderReleased`, following the confidence slider — dragging would otherwise fire
one control command per pixel.

**`framediff` reached the UI with working controls and zero GUI code.** That is
the whole point of the change.

### framediff

Motion by temporal difference against a running average of the scene, with
`sensitivity`, `decay` and an overlay/mask/heat render mode. The running average
is what makes it more than a naive frame-to-frame diff: a parked object fades
into the background over about a second instead of flickering forever, and slow
lighting drift is absorbed rather than reported as motion.

It is also the first stage that keeps state between frames. State is per
instance, and every chain gets its own objects, so two cameras never share a
background model.

### A bug found on the way

`algos 0 <typo>` replied `OK` and streamed an empty chain — unknown names were
skipped silently. The whole request is now rejected with `INVALID_ARGS`.

## Testing

`ctest` passes. The new `algorithms` suite adds nine cases, and **two of them
walk the whole registry**: every schema must be well-formed (`min < max`, default
in range, enum choices present, lowercase name), and every algorithm's `apply()`
must preserve the frame's size and type — at its defaults *and* at both extremes
of every knob it declares. Those two enforce the `Algorithm` contract
mechanically, so an algorithm added later is covered without anyone remembering
to write a test for it.

The rest cover the registry as single source of truth, unknown-name rejection,
clamping, tuning surviving a chain rebuild, id bounds checks, and framediff's
behaviour: a still scene must report no motion, and a moved block must light up
where it went *and* where it left, and nowhere else.

Console: `--selftest-stream` passes (`fps=15.0 res=1920x1080`), and the
screenshot tour shows FRAMEDIFF discovered from the daemon with CANNY's two
thresholds and FRAMEDIFF's three controls rendering correctly.

Bench, one camera, MJPEG 720p, one sitting:

| Chain | fps | dropped |
|---|---|---|
| (none) | 15.06 | 0 |
| `framediff` | 15.06 | 0 |
| `canny` | 15.07 | 0 |

**That is a budget statement, not a cost measurement.** Auto-exposure held the
camera at 15 fps that afternoon — the same mode measured 20.1 fps in better light
for the existing baseline — so each frame had ~66 ms of slack and a stage costing
a few ms cannot show up. `dropped:` would have moved first, and it did not.
Measuring real per-stage cost needs a synthetic source; that is noted in
`docs/PERFORMANCE.md` rather than left implied.

## Notes for review

- **The CI cache key now hashes `scripts/build-opencv.sh`.** `BUILD_LIST` lives
  in that script and the old key did not cover it, so a cache built before the
  module change would have been restored and failed the engine build on a missing
  header. First CI run on this branch rebuilds OpenCV; later ones hit the cache.
- **Algorithm names must be lowercase.** The console stores the name in a
  checkbox caption and round-trips it through upper case, so `motionBoxes` would
  come back as an unknown name. A registry test enforces this. Hyphens are fine.
- Two things to settle before the motion stages that follow: `stats <id>` returns
  the **first** stage reporting telemetry, so `detect` + a future `motion-boxes`
  in one chain would hide one of them; and `MultiGridPage` still hardcodes its
  four modes, so new algorithms do not appear there.
- MOG2 is ~10–15 ms at 1080p and the chain holds `FrameProcessor::m_mutex` for
  its whole duration. The stages after this one should analyse a downscaled copy
  and scale results back up for drawing.