### PR TITLE
fix: report telemetry from every stage, and take the poll off the frame mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ interactively: run the engine without arguments for a REPL, or
 | `models` | model listing | Detector models installed in `models/` |
 | `model <id> [name]` | `OK <name>` | Load a detector model (no name unloads it) |
 | `detect-params <id> <conf> <nms> [draw]` | `OK` | Detector thresholds and box overlay |
-| `stats <id>` | stats + detections | Inference latency and the last result |
+| `stats <id>` | stats + detections | Per-stage latency and the last result. The first block is the legacy detector shape; a `stage`/`stage-det` block then repeats it and follows with every other reporting stage |
 | `start <id>` | `OK <video-socket-path>` | Start streaming; reply carries the data-plane socket |
 | `stop <id>` | `OK` | Stop streaming |
 | `delete <id>` | `OK remaining=N` | Destroy a pipeline (**ids shift down** — clients re-map) |

--- a/concept_A/MediaFusionGCV/FrameProcessor.cpp
+++ b/concept_A/MediaFusionGCV/FrameProcessor.cpp
@@ -51,7 +51,7 @@ bool FrameProcessor::setAlgorithms(const std::vector<std::string>& names)
         params = m_algoParams;
     }
 
-    std::vector<std::unique_ptr<Algorithm>> built;
+    std::vector<std::shared_ptr<Algorithm>> built;
     built.reserve(names.size());
     for (const auto& n : names) {
         auto a = makeAlgorithm(n);
@@ -72,6 +72,12 @@ bool FrameProcessor::setAlgorithms(const std::vector<std::string>& names)
 
     std::lock_guard<std::mutex> lk(m_mutex);
     m_algos = std::move(built);
+    {
+        // Publish the same stages for the telemetry poll to read without ever
+        // touching m_mutex. Done inside this scope so the two cannot diverge.
+        std::lock_guard<std::mutex> sk(m_statsMutex);
+        m_statsStages = m_algos;
+    }
     return true;
 }
 
@@ -154,10 +160,18 @@ DetectorConfig FrameProcessor::detectorConfig() const
 
 std::vector<InferenceStats> FrameProcessor::stageStats() const
 {
-    std::lock_guard<std::mutex> lk(m_mutex);
+    // Copy the pointers, then let the lock go before asking any stage anything.
+    // Holding m_statsMutex across snapshotStats() would be harmless today, but
+    // the point of this path is that a poll never waits on the frame path, and
+    // the shorter the window the easier that stays true.
+    std::vector<std::shared_ptr<Algorithm>> stages;
+    {
+        std::lock_guard<std::mutex> lk(m_statsMutex);
+        stages = m_statsStages;
+    }
 
     std::vector<InferenceStats> out;
-    for (const auto& a : m_algos) {
+    for (const auto& a : stages) {
         InferenceStats st;
         // snapshotStats() clears its output first, so the name goes on after.
         if (a->snapshotStats(st)) {

--- a/concept_A/MediaFusionGCV/FrameProcessor.cpp
+++ b/concept_A/MediaFusionGCV/FrameProcessor.cpp
@@ -152,13 +152,20 @@ DetectorConfig FrameProcessor::detectorConfig() const
     return m_detectorConfig;
 }
 
-bool FrameProcessor::inferenceStats(InferenceStats& out) const
+std::vector<InferenceStats> FrameProcessor::stageStats() const
 {
     std::lock_guard<std::mutex> lk(m_mutex);
-    for (const auto& a : m_algos)
-        if (a->snapshotStats(out))
-            return true;
-    return false;
+
+    std::vector<InferenceStats> out;
+    for (const auto& a : m_algos) {
+        InferenceStats st;
+        // snapshotStats() clears its output first, so the name goes on after.
+        if (a->snapshotStats(st)) {
+            st.stage = a->name();
+            out.push_back(std::move(st));
+        }
+    }
+    return out;
 }
 
 std::vector<std::string> FrameProcessor::activeAlgorithms() const

--- a/concept_A/MediaFusionGCV/FrameProcessor.h
+++ b/concept_A/MediaFusionGCV/FrameProcessor.h
@@ -67,6 +67,8 @@ public:
     // empty when no stage reports. Deliberately a list rather than "the stats":
     // more than one stage can report (a detector and a motion stage), and
     // returning only the first hid the others with no error and no clue.
+    //
+    // This does NOT take m_mutex — see m_statsStages below.
     std::vector<InferenceStats> stageStats() const;
 
 private:
@@ -78,10 +80,29 @@ private:
     // default is picked up instead of being pinned by a stale copy.
     std::map<std::string, AlgorithmParams>  m_algoParams;
 
-    std::vector<std::unique_ptr<Algorithm>> m_algos;
+    // shared_ptr rather than unique_ptr so stageStats() can hold a stage alive
+    // without holding a lock — see m_statsStages.
+    std::vector<std::shared_ptr<Algorithm>> m_algos;
     DetectorConfig                          m_detectorConfig;
     AccelBackend                            m_accel = AccelBackend::CPU;
     mutable std::mutex                      m_mutex;
+
+    // The same stages again, behind their own lock, so a telemetry poll never
+    // queues behind a frame: m_mutex is held for the WHOLE algorithm chain on
+    // every buffer, so reading stats through it made the 1 Hz poll wait out a
+    // frame's OpenCV work and report a sample time it had not actually taken
+    // (docs/PERFORMANCE.md, P15).
+    //
+    // stageStats() copies these pointers, releases m_statsMutex, and only then
+    // calls snapshotStats(). Shared ownership is what makes letting go of the
+    // lock safe: setAlgorithms() may drop the chain meanwhile, and
+    // ~DetectorAlgorithm joins a worker thread that can be mid-forward-pass, so
+    // a raw pointer would be either a crash or a ~57 ms wait.
+    //
+    // Lock order is m_mutex -> m_statsMutex, in setAlgorithms() and nowhere
+    // else; stageStats() takes only the second, so there is no cycle.
+    std::vector<std::shared_ptr<Algorithm>> m_statsStages;
+    mutable std::mutex                      m_statsMutex;
     GstVideoInfo                            m_info;
     bool                                    m_haveInfo = false;
     gulong                                  m_probeId  = 0;

--- a/concept_A/MediaFusionGCV/FrameProcessor.h
+++ b/concept_A/MediaFusionGCV/FrameProcessor.h
@@ -63,8 +63,11 @@ public:
     bool           setDetectorConfig(const DetectorConfig& cfg);
     DetectorConfig detectorConfig() const;
 
-    // Stats from the inference stage; false when no detector is in the chain.
-    bool inferenceStats(InferenceStats& out) const;
+    // What every reporting stage in the chain last produced, in chain order;
+    // empty when no stage reports. Deliberately a list rather than "the stats":
+    // more than one stage can report (a detector and a motion stage), and
+    // returning only the first hid the others with no error and no clue.
+    std::vector<InferenceStats> stageStats() const;
 
 private:
     static GstPadProbeReturn onBuffer(GstPad* pad, GstPadProbeInfo* info, gpointer user);

--- a/concept_A/MediaFusionGCV/InferenceStats.h
+++ b/concept_A/MediaFusionGCV/InferenceStats.h
@@ -22,6 +22,11 @@ struct Detection
 
 struct InferenceStats
 {
+    // Which stage produced this. A chain can hold more than one stage that
+    // reports — an object detector and a motion stage, say — and their numbers
+    // mean different things, so a block without a name on it is not readable.
+    std::string stage;                 // algorithm wire name, e.g. "detect"
+
     bool        modelLoaded = false;   // a net is resident and usable
     std::string modelName;             // "" when no model is selected
     std::string lastError;             // load/run failure, "" when healthy

--- a/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
+++ b/concept_A/MediaFusionGCV/MediaFusionGCV_API.cpp
@@ -345,11 +345,15 @@ const char* mediaLib_availableModels()
 	return listing.c_str();
 }
 
-errorState mediaLib_getInferenceStats(size_t pipelineId, InferenceStats& stats)
+errorState mediaLib_getInferenceStats(size_t pipelineId, std::vector<InferenceStats>& stats)
 {
+	stats.clear();
 	if (pipelineId >= pipelines.size() || pipelines[pipelineId] == nullptr)
 		return errorState::NULLPTR_ERR;
-	if (!pipelines[pipelineId]->inferenceStats(stats))
+	stats = pipelines[pipelineId]->stageStats();
+	// An empty chain, or one of plain pixel ops, is a normal state rather than a
+	// failure — the caller reports "nothing to say" instead of an error.
+	if (stats.empty())
 		return errorState::NOT_IMPLEMENTED_YET_ERR;
 	return errorState::NO_ERR;
 }

--- a/concept_A/MediaFusionGCV/MediaFusionGCV_API.h
+++ b/concept_A/MediaFusionGCV/MediaFusionGCV_API.h
@@ -105,9 +105,13 @@ extern "C" {
 	// Empty when no weights are installed. Pointer valid until the next call.
 	MEDIAFUSIONGCV_API const char* mediaLib_availableModels();
 
-	// Last completed inference for this pipeline. NULLPTR_ERR for a bad id,
-	// NOT_IMPLEMENTED_YET_ERR when the chain has no inference stage.
-	MEDIAFUSIONGCV_API errorState  mediaLib_getInferenceStats(size_t, InferenceStats&);
+	// What each reporting stage in this pipeline last produced, in chain order.
+	// A list rather than one struct because a chain may hold more than one stage
+	// that reports (an object detector and a motion stage), and each block names
+	// its own stage. NULLPTR_ERR for a bad id, NOT_IMPLEMENTED_YET_ERR when no
+	// stage in the chain reports — a normal state, not a failure.
+	MEDIAFUSIONGCV_API errorState  mediaLib_getInferenceStats(size_t,
+	                                                          std::vector<InferenceStats>&);
 
 	// Acceleration backends detected on this host (probed once at init). One line
 	// per backend: "backend=<cpu|vulkan|cuda> available=<0|1> device=<name>".

--- a/concept_A/MediaFusionGCV/PipelineManager.cpp
+++ b/concept_A/MediaFusionGCV/PipelineManager.cpp
@@ -268,9 +268,11 @@ errorState PipelineManager::setDetectorParams(float confidence, float nms, bool 
     return errorState::NO_ERR;
 }
 
-bool PipelineManager::inferenceStats(InferenceStats& out) const
+std::vector<InferenceStats> PipelineManager::stageStats() const
 {
-    return processor && processor->valid() && processor->inferenceStats(out);
+    if (!processor || !processor->valid())
+        return {};
+    return processor->stageStats();
 }
 
 // The GStreamer element chain that does the colorspace convert on the GPU for a

--- a/concept_A/MediaFusionGCV/PipelineManager.h
+++ b/concept_A/MediaFusionGCV/PipelineManager.h
@@ -59,8 +59,9 @@ public:
     errorState setDetectorModel(const std::string& modelNameOrPath);
     errorState setDetectorParams(float confidence, float nms, bool drawBoxes);
 
-    // False when this pipeline has no inference stage in its chain.
-    bool inferenceStats(InferenceStats& out) const;
+    // What each reporting stage in this pipeline's chain last produced, in chain
+    // order. Empty when no stage reports, which includes having no chain at all.
+    std::vector<InferenceStats> stageStats() const;
 
     // Acceleration backend selection (auto/cpu/vulkan/cuda). Resolved against the
     // detected hardware at the next startStreaming(), since the choice shapes the

--- a/concept_A/MediaFusionGCV/main.cpp
+++ b/concept_A/MediaFusionGCV/main.cpp
@@ -106,7 +106,7 @@ static std::string helpText()
         << "  models                            -- lists the installed ONNX models\n"
         << "  model 0 yolov5n                   -- loads one into pipeline 0\n"
         << "  algos 0 detect                    -- puts the inference stage in the chain\n"
-        << "  stats 0                           -- inference latency and last detections\n"
+        << "  stats 0                           -- per-stage latency and last detections\n"
         << "\n"
         << "Commands:\n"
         << "  create <src> <snk> <name>        Create a pipeline\n"
@@ -125,7 +125,7 @@ static std::string helpText()
         << "  detect-params <id> <conf> <nms> [draw]\n"
         << "                                   Detector thresholds (0..1) and box overlay (0/1)\n"
         << "  accel <id> <auto|cpu|vulkan|cuda>  Select accel backend (applied at next start)\n"
-        << "  stats <id>                       Inference latency and last detections\n"
+        << "  stats <id>                       Per-stage latency and last detections\n"
         << "  start <id>                       Start streaming (app sink -> prints socket path)\n"
         << "  stop <id>                        Stop streaming\n"
         << "  delete <id>                      Delete pipeline\n"
@@ -348,30 +348,61 @@ static std::string handleCommand(const std::string& line)
         if (!(iss >> id))
             out << "ERR INVALID_ARGS stats <id>\n";
         else {
-            InferenceStats st;
-            errorState err = mediaLib_getInferenceStats(id, st);
+            std::vector<InferenceStats> stages;
+            errorState err = mediaLib_getInferenceStats(id, stages);
             if (err == errorState::NOT_IMPLEMENTED_YET_ERR) {
-                // No inference stage in this pipeline — a normal state, not a
+                // No reporting stage in this pipeline — a normal state, not a
                 // failure: report it in the same shape so clients parse one form.
                 out << "OK model= loaded=0 infer_ms=0 avg_ms=0 inferred=0 skipped=0"
                        " objects=0 avg_conf=0\n";
             } else if (err != errorState::NO_ERR) {
                 out << "ERR " << errStr(err) << "\n";
             } else {
-                out << "OK model=" << st.modelName
-                    << " loaded="   << (st.modelLoaded ? 1 : 0)
-                    << " infer_ms=" << st.inferenceMs
-                    << " avg_ms="   << st.avgInferenceMs
-                    << " inferred=" << st.framesInferred
-                    << " skipped="  << st.framesSkipped
-                    << " objects="  << st.objectCount
-                    << " avg_conf=" << st.avgConfidence << "\n";
-                for (const auto& d : st.detections)
+                // First block: byte for byte what this verb has always replied,
+                // because a client written against it reads these lines and
+                // ignores everything after.
+                const InferenceStats& first = stages.front();
+                out << "OK model=" << first.modelName
+                    << " loaded="   << (first.modelLoaded ? 1 : 0)
+                    << " infer_ms=" << first.inferenceMs
+                    << " avg_ms="   << first.avgInferenceMs
+                    << " inferred=" << first.framesInferred
+                    << " skipped="  << first.framesSkipped
+                    << " objects="  << first.objectCount
+                    << " avg_conf=" << first.avgConfidence << "\n";
+                for (const auto& d : first.detections)
                     out << "det conf=" << d.confidence
                         << " box="     << d.x << "," << d.y << "," << d.width << "," << d.height
                         << " label="   << d.label << "\n";   // label last: it may contain spaces
-                if (!st.lastError.empty())
-                    out << "error=" << st.lastError << "\n";
+                if (!first.lastError.empty())
+                    out << "error=" << first.lastError << "\n";
+
+                // Then every stage in one uniform shape, the first one included.
+                // Repeating it is deliberate: a client reading only `stage` lines
+                // gets the whole chain from one format, instead of having to
+                // merge the block above with the ones below to see every stage.
+                // The prefixes are chosen so a client written against the old
+                // reply skips these lines rather than mistaking them for `det`.
+                for (const auto& st : stages) {
+                    out << "stage name=" << st.stage
+                        << " model="     << st.modelName
+                        << " loaded="    << (st.modelLoaded ? 1 : 0)
+                        << " infer_ms="  << st.inferenceMs
+                        << " avg_ms="    << st.avgInferenceMs
+                        << " inferred="  << st.framesInferred
+                        << " skipped="   << st.framesSkipped
+                        << " objects="   << st.objectCount
+                        << " avg_conf="  << st.avgConfidence << "\n";
+                    // A stage-det belongs to the `stage` line above it, the same
+                    // positional rule `det` already follows.
+                    for (const auto& d : st.detections)
+                        out << "stage-det conf=" << d.confidence
+                            << " box="   << d.x << "," << d.y << "," << d.width << "," << d.height
+                            << " label=" << d.label << "\n";
+                    if (!st.lastError.empty())
+                        out << "stage-error name=" << st.stage
+                            << " error=" << st.lastError << "\n";
+                }
             }
         }
     }

--- a/concept_A/MediaFusionGCV/tests/test_inference.cpp
+++ b/concept_A/MediaFusionGCV/tests/test_inference.cpp
@@ -70,11 +70,12 @@ GST_END_TEST
 GST_START_TEST(test_inference_api_bounds_checks)
 {
     const size_t bogus = 9999;
-    InferenceStats stats;
+    std::vector<InferenceStats> stats;
 
     fail_unless(mediaLib_setDetectorModel(bogus, "x")     == errorState::NULLPTR_ERR, "model");
     fail_unless(mediaLib_setDetectorParams(bogus, 0.5f, 0.5f, true) == errorState::NULLPTR_ERR, "params");
     fail_unless(mediaLib_getInferenceStats(bogus, stats)  == errorState::NULLPTR_ERR, "stats");
+    fail_unless(stats.empty(), "a bad id must not leave stats behind");
 }
 GST_END_TEST
 
@@ -87,10 +88,20 @@ GST_START_TEST(test_params_without_model_and_stats_absent)
     fail_unless(mediaLib_setDetectorParams(id, 0.4f, 0.5f, true) == errorState::NO_ERR,
         "thresholds must be settable before a model is chosen");
 
-    InferenceStats stats;
+    std::vector<InferenceStats> stats;
     errorState r = mediaLib_getInferenceStats(id, stats);
     fail_unless(r == errorState::NOT_IMPLEMENTED_YET_ERR,
         "a chain without 'detect' must report NOT_IMPLEMENTED_YET_ERR, got %d", (int)r);
+    fail_unless(stats.empty(), "a chain with nothing to report must return no blocks");
+
+    // Plain pixel ops are not "no chain" -- they are a chain with nothing to
+    // say, and must be reported the same way rather than as an error.
+    fail_unless(mediaLib_setAlgorithms(id, "grayscale,motion") == errorState::NO_ERR,
+        "a non-reporting chain must be selectable");
+    r = mediaLib_getInferenceStats(id, stats);
+    fail_unless(r == errorState::NOT_IMPLEMENTED_YET_ERR,
+        "a chain of non-reporting stages must report NOT_IMPLEMENTED_YET_ERR, got %d", (int)r);
+    fail_unless(stats.empty(), "non-reporting stages must not produce blocks");
 
     mediaLib_delete(id);
 }
@@ -210,6 +221,47 @@ GST_START_TEST(test_accel_api)
 }
 GST_END_TEST
 
+// Telemetry is reported per stage rather than "whichever stage answers first".
+// The old accessor returned the first reporting stage and dropped the rest, so a
+// chain holding two of them showed one and gave no sign the other existed.
+//
+// Note what this can and cannot prove today: `detect` is still the only stage
+// that implements snapshotStats(), so the two-reporting-stages case cannot be
+// exercised here. What is checked is that the plumbing carries a list, names
+// every block, and keeps chain order — the parts that would have to be rebuilt
+// otherwise. The genuine two-stage assertion belongs with the stage that adds
+// the second reporter.
+GST_START_TEST(test_stats_are_reported_per_stage)
+{
+    const size_t id = mediaLib_create(SourceType::CAMERA_SOURCE, SinkType::APPLICATION_SINK, "t_stages");
+
+    // A reporting stage sat between two silent ones: the block must come back
+    // named, and the silent neighbours must not produce empty blocks.
+    fail_unless(mediaLib_setAlgorithms(id, "grayscale,detect,motion") == errorState::NO_ERR,
+        "the chain must be selectable");
+
+    std::vector<InferenceStats> stats;
+    const errorState r = mediaLib_getInferenceStats(id, stats);
+    fail_unless(r == errorState::NO_ERR,
+        "a chain containing 'detect' must report stats, got %d", (int)r);
+    fail_unless(stats.size() == 1,
+        "expected one reporting stage in 'grayscale,detect,motion', got %zu", stats.size());
+    fail_unless(stats.front().stage == "detect",
+        "the block must name the stage that produced it, got '%s'",
+        stats.front().stage.c_str());
+
+    // Rebuilding the chain has to republish what the poll reads, or telemetry
+    // would keep describing a chain that is no longer running.
+    fail_unless(mediaLib_setAlgorithms(id, "canny") == errorState::NO_ERR,
+        "the chain must be replaceable");
+    fail_unless(mediaLib_getInferenceStats(id, stats) == errorState::NOT_IMPLEMENTED_YET_ERR,
+        "after dropping 'detect' the pipeline must report nothing");
+    fail_unless(stats.empty(), "a replaced chain left stale blocks behind");
+
+    mediaLib_delete(id);
+}
+GST_END_TEST
+
 Suite* inference_suite()
 {
     Suite* s = suite_create("inference");
@@ -224,6 +276,7 @@ Suite* inference_suite()
     tcase_add_test(tc, test_unknown_model_is_rejected);
     tcase_add_test(tc, test_inference_api_bounds_checks);
     tcase_add_test(tc, test_params_without_model_and_stats_absent);
+    tcase_add_test(tc, test_stats_are_reported_per_stage);
     tcase_add_test(tc, test_model_registry_entries_are_resolvable);
     tcase_add_test(tc, test_detector_runs_when_a_model_is_installed);
     tcase_add_test(tc, test_accelerators_detection_invariants);

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -114,6 +114,31 @@ motion analysis more expensive, only the resize and the blend. And `overlay` mod
 costs ~1.6 ms more than `mask` at 1080p — a full-frame `clone` + `addWeighted`
 that a later pass could narrow to the mask's bounding box.
 
+### Cost of the telemetry poll (P15)
+
+`stats <id>` round trip over the control socket, 300 polls at ~15 ms while
+streaming 1920×1080, measured 2026-08-07. The console polls this once a second.
+
+| Chain | | mean | median | p95 | max | over 1 ms |
+|---|---|---|---|---|---|---|
+| `motion` | before | 0.272 ms | 0.112 ms | 1.337 ms | **4.702 ms** | 22 / 300 |
+| `motion` | after | 0.111 ms | 0.112 ms | 0.141 ms | **0.550 ms** | 0 / 300 |
+| `motion,detect` | before | 0.262 ms | 0.113 ms | 1.779 ms | **3.522 ms** | 18 / 300 |
+| `motion,detect` | after | 0.113 ms | 0.113 ms | 0.146 ms | **0.192 ms** | 0 / 300 |
+
+**Read the median and the max together — that is the whole story.** The median
+never moved: a poll that lands between frames was always fast. What was wrong is
+that ~7% of polls landed *inside* a frame's processing window and paid the entire
+chain for it, which is why the worst case sat at 4.7 ms — `motion`'s own
+per-frame cost, measured independently above as 4.4 ms. That is not a coincidence;
+it is the mutex.
+
+After the fix the tail is gone outright: not one poll in 600 crossed a
+millisecond. This never cost throughput, which is why it sat in the backlog at
+"low" — but a latency chart whose own sample instants are delayed by the pipeline
+is a chart that misreports the thing it exists to measure, and every stage added
+to the motion family would have made it worse.
+
 ## Landed
 
 | # | Item | Where |
@@ -122,6 +147,7 @@ that a later pass could narrow to the mask's bounding box.
 | P2 | `videoconvert n-threads=0`. It defaults to **1**, so the per-camera colourspace convert was single-threaded on both sides | `PipelineManager.cpp` ctor, `StreamReceiver.cpp` |
 | P3 | Cap OpenCV's thread pool at ¼ of the cores (`MEDIAFUSION_CV_THREADS` overrides; `0` disables the cap). Left alone OpenCV takes every core for each `forward()`, so N cameras meant N×cores runnable threads evicting the capture threads | `MediaFusionGCV_API.cpp` |
 | P4 | `queue max-size-buffers=3 leaky=downstream` directly after the source. The only queue used to be at the *end* of the chain, so capture, convert and every OpenCV stage ran in one thread and any hiccup stalled buffer dequeue — driver-level frame drops | `GStreamerSource.h`, `PipelineManager.cpp` |
+| P15 | **Stats poll off the frame mutex.** `inferenceStats()` took `m_mutex`, which the streaming thread holds for the *whole* algorithm chain, so the telemetry poll waited out a frame's OpenCV work. `FrameProcessor` now publishes the chain a second time behind its own lock (`m_statsStages`, shared_ptr so the poll can let go of the lock before asking a stage anything) and the poll never touches `m_mutex`. Measured below | `FrameProcessor.{h,cpp}` |
 | P5 | **MJPEG capture.** Enumeration filtered everything except `video/x-raw`, so only uncompressed modes were selectable; a decoder (`jpegdec`, else `avdec_mjpeg`) is now spliced in when an encoded mode is chosen. 720p YUYV is ~55 MB/s (~440 Mbit/s) — two cameras cannot both fit on one USB 2.0 bus (480 Mbit/s shared) and the UVC driver starves the second one | `GStreamerSourceCamera.cpp`, `PipelineManager.cpp`, `DeviceParser.cpp` |
 
 ## Backlog
@@ -140,7 +166,6 @@ S (a sitting), M (a session), L (multi-session or needs a design decision).
 | P12 | Share one detector/model across pipelines | high | L | open |
 | P13 | Carry YUYV/NV12 over the IPC socket, convert once at the sink | high | L | open |
 | P14 | Share one GL context/display across tiles | med | L | open |
-| P15 | Narrow `FrameProcessor::m_mutex` so `stats` does not block on a frame | low | S | open |
 | P16 | Keep watching the bus after the first message | low | S | open |
 | P17 | Revisit `sync=false` on both sinks — nothing paces or sheds on the clock | med | M | open |
 | P18 | VA-API hardware JPEG decode (`vajpegdec`) | med | M | open |
@@ -152,8 +177,8 @@ S (a sitting), M (a session), L (multi-session or needs a design decision).
 
 **The motion stages downscale for analysis.** `framediff` is single-channel and
 cheap. Its successors are not — the measurement above puts full-frame MOG2 at
-10.6 ms at 1080p, and dense optical flow will be far worse — and the whole chain
-runs on the streaming thread holding `FrameProcessor::m_mutex` (see P15). So
+10.7 ms at 1080p, and dense optical flow will be far worse — and the whole chain
+runs on the streaming thread, so a stage's cost is the stream's cost. So
 `motion` runs its subtractor on a 360-row copy and scales the mask back up to
 draw, which more than halves it; a motion mask does not need 1080p. **Every later
 stage in the family should do the same**, and M3's boxes should be found at
@@ -219,11 +244,6 @@ Interacts with P6 and with the in-place pad-probe contract below.
 `glimagesink`, so a 2×2 grid is four GL contexts, four context threads and four
 texture pools. `gstglcontext` sharing via a `GstGLDisplay` on the pipeline bus is
 the supported route.
-
-**P15 — processor mutex.** `FrameProcessor::m_mutex` is held for the entire
-algorithm chain on every frame, and `inferenceStats()` takes the same mutex, so
-the 1 Hz stats poll blocks behind a frame's worth of OpenCV work. Jitter, not
-throughput — but it makes the telemetry lie about its own sample time.
 
 **P16 — bus loop.** `PipelineManager::startLoop` `break`s out of the poll loop
 after the *first* message, so one mid-stream error is logged and then nothing is


### PR DESCRIPTION
# fix: report telemetry from every stage, and take the poll off the frame mutex

> **Base this on `feat/algo-motion`, not `main`.** This sits on top of M2 of the
> motion track, which sits on `feat/algorithm-registry-params`. Neither has merged
> yet. Against `main` the diff would carry all three.

Two defects in the same twenty lines of `FrameProcessor`. Both had to go before
M3 `motion-boxes`, which is the first motion stage that publishes telemetry —
doing them here keeps a protocol change out of a feature diff.

## What changed

| Commit | Change |
|---|---|
| `0a26937` | Stats become a list: every reporting stage, in chain order, each block named |
| `7fd2ce0` | The telemetry poll stops taking the mutex the frame path holds |
| `8b34a1f` | Protocol row, and P15 moved to Landed with its measurement |

## The collision

`FrameProcessor::inferenceStats` walked the chain and returned the **first** stage
whose `snapshotStats()` succeeded. Today only `detect` reports, so nothing looks
wrong. The moment `detect` and `motion-boxes` sit in one chain the second one is
invisible — no error, no empty reply, just a console showing one stage's numbers
with no hint the other exists. Silent wrong-answer bugs are the ones worth paying
to fix before they can bite.

`inferenceStats(InferenceStats&)` is now:

```cpp
std::vector<InferenceStats> stageStats() const;   // chain order, reporting stages only
```

and `InferenceStats` carries the wire name of the stage that produced it.

**Replaced rather than supplemented.** The C API entry points sit inside
`extern "C"` and cannot be overloaded, so the signature moves to
`mediaLib_getInferenceStats(size_t, std::vector<InferenceStats>&)` — and keeping a
first-wins accessor alongside a complete one is exactly how this bug comes back.
The only callers are `main.cpp` and the tests; the console does not link the
library.

## The wire format

The first block is **byte for byte** what this verb has always replied, and every
stage then repeats in one uniform shape:

```
OK model=yolov5n loaded=1 infer_ms=73.41 avg_ms=71.79 inferred=104 skipped=77 objects=3 avg_conf=0.33
det conf=0.395 box=382,556,196,160 label=person
det conf=0.325 box=963,593,41,121 label=book
stage name=detect model=yolov5n loaded=1 infer_ms=73.41 avg_ms=71.79 inferred=104 skipped=77 objects=3 avg_conf=0.33
stage-det conf=0.395 box=382,556,196,160 label=person
stage-det conf=0.325 box=963,593,41,121 label=book
```

The first stage appears twice, deliberately. A new client reads only
`stage`/`stage-det` and gets the whole chain from **one** format, rather than
having to merge the legacy header with the blocks below it to see every stage.
That costs a few lines at 1 Hz.

The prefixes were chosen against the console's actual parser, not by taste:
`parseStats` matches only lines beginning `det `, `error=` or `OK` and ignores
everything else. `stage ` and `stage-det ` match none of those — in particular
`stage-det ` does not start with `det `, so detections are not counted twice.
`label=` stays last, per the house rule for fields that may contain spaces.
`stage-det` belongs to the `stage` line above it, the same positional rule `det`
already follows.

## P15 — the poll stops waiting on a frame

`inferenceStats()` took `m_mutex`, which the streaming thread holds for the
**entire** algorithm chain on every buffer. Tolerable when the chain was a 1 ms
canny; M2 made it 4.4 ms at 1080p and everything after it is heavier.

`FrameProcessor` now publishes the chain a second time behind its own lock.
`stageStats()` copies those pointers, **releases the lock**, and only then calls
`snapshotStats()` — it never touches `m_mutex`.

`m_algos` moved from `unique_ptr` to `shared_ptr`, and that is the load-bearing
part: a concurrent `setAlgorithms` may drop the chain, and `~DetectorAlgorithm`
joins a worker thread that can be mid-forward-pass. A raw pointer would be either
a crash or a ~57 ms wait for the very poll this change is trying to make fast.
Lock order is `m_mutex` → `m_statsMutex` in `setAlgorithms` and nowhere else;
`stageStats()` takes only the second, so there is no cycle.

### Measured

300 polls at ~15 ms over the control socket while streaming 1920×1080:

| Chain | | mean | median | p95 | max | over 1 ms |
|---|---|---|---|---|---|---|
| `motion` | before | 0.272 ms | 0.112 ms | 1.337 ms | **4.702 ms** | 22 / 300 |
| `motion` | after | 0.111 ms | 0.112 ms | 0.141 ms | **0.550 ms** | 0 / 300 |
| `motion,detect` | before | 0.262 ms | 0.113 ms | 1.779 ms | **3.522 ms** | 18 / 300 |
| `motion,detect` | after | 0.113 ms | 0.113 ms | 0.146 ms | **0.192 ms** | 0 / 300 |

**Read the median and the max together — that is the whole story.** The median
never moved: a poll landing between frames was always fast. What was wrong is
that ~7% of polls landed *inside* a frame's processing window and paid the entire
chain, which is why the worst case sat at 4.7 ms — `motion`'s own per-frame cost,
measured independently on the previous branch at 4.4 ms. That is not a
coincidence, it is the mutex. Afterwards not one poll in 600 crossed a
millisecond.

This never cost throughput, which is why it sat in the backlog at "low". But a
latency chart whose own sample instants are delayed by the pipeline misreports
the thing it exists to measure, and every stage added to the motion family would
have made it worse.

## Testing

`ctest` passes — 40 checks. New coverage: a chain of `grayscale,detect,motion`
returns exactly one block, named `detect`, proving silent stages produce nothing
and the reporting one is found in the middle of a chain rather than at its head;
replacing the chain republishes what the poll reads, so telemetry cannot keep
describing a chain that stopped running; a chain of purely non-reporting stages is
`NOT_IMPLEMENTED_YET_ERR` with no blocks, which is a normal state and not an
error; and a bad id leaves the caller's vector empty.

**The compatibility claim is checked, not argued.** The legacy block was diffed
before and after against a live daemon reply — identical, token for token. Then
the console's *own* `parseStats` was run over the new reply: 3 detections, not 6,
with every scalar field matching what it parsed from the old one. That is the
specific failure this format was designed to avoid, so it is worth demonstrating
rather than reasoning about.

`--selftest-stream` passes (`fps=22.0 res=1920x1080`) and the screenshot tour is
clean.

## Notes for review

- **The console is untouched on purpose.** Nothing emits a second block until M3,
  and the old parser already ignores the new lines safely. The real reason is
  that *what the console should do* with several reporting stages is an M3 design
  question — does the Analytics chart follow the detector or the heaviest stage?
  Does DETECTION_SUMMARY sum them or pick one? Building the parser now, with no
  test harness on the GUI side and no screen to render it, risks building the
  wrong shape. M3 adds it alongside the UI that justifies it.
- **The two-reporting-stages case cannot be tested on this branch.** `detect` is
  still the only stage implementing `snapshotStats()`. What is proven here is
  that the plumbing carries a list, names every block and keeps chain order — the
  parts that would otherwise have to be rebuilt. The genuine two-stage assertion
  belongs with M3, and should be written as part of it. Adding a fake reporting
  stage to the registry purely to test this would put a non-feature in the
  operator's algorithm menu, which is a worse trade.
- The two commits are split so the perf change is bisectable on its own. The
  intermediate state — the list fix, still on `m_mutex` — was built and passes the
  full suite by itself.